### PR TITLE
776 docs publish docs for minor version not for every patch

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -3,8 +3,7 @@ on:
     push:
         branches:
             - main
-            - master
-            - 776-docs-publish-docs-for-minor-version-not-for-every-patch
+
 permissions:
     contents: write
 jobs:

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -4,6 +4,7 @@ on:
         branches:
             - main
             - master
+            - 776-docs-publish-docs-for-minor-version-not-for-every-patch
 permissions:
     contents: write
 jobs:
@@ -22,7 +23,7 @@ jobs:
                 path: .cache
             - run: pip install -e ".[dev]"
             - run: ./scripts/build-docs.sh
-            - run: echo "VERSION=$(python3 -c 'from importlib.metadata import version; print(version("""faststream"""))')" >> $GITHUB_ENV
+            - run: echo "VERSION=$(python3 -c 'from importlib.metadata import version; print(".".join(version("faststream").split(".")[:2]))')" >> $GITHUB_ENV
             - name: Configure Git user
               run: |
                 git config --local user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
# Description

Publish documentation under minor version instead of patch (e.g. 0.1 instead of 0.1.x).

Fixes # (issue number)

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)

## Checklist

- [ ] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [ ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-anaylysis.sh`
- [ ] I have included code examples to illustrate the modifications
