### PR TITLE
Use redirect template with mike

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -29,18 +29,5 @@ jobs:
                 git config --local user.name "github-actions[bot]"
             - run: echo $VERSION
             # - run: cd docs && mike delete --all
-            - run: cd docs && mike deploy --update-aliases $VERSION latest
-            - run: cd docs && mike set-default latest
-            - name: Add social tags
-              run: |
-                og_tags_to_add=$(grep -E '<meta property="og:|<meta name="twitter:' "docs/site/index.html")
-                echo "$og_tags_to_add"
-                git checkout gh-pages
-                destination_html_file="index.html"
-                destination_html=$(cat "$destination_html_file")
-                modified_destination_html=${destination_html/\<\/head\>/"$og_tags_to_add"$'\n'\<\/head\>}
-                echo "$modified_destination_html" > "$destination_html_file"
-
-                git add "$destination_html_file"
-                git commit -m "Add og meta tags in index.html"
-                git push -u origin gh-pages
+            - run: cd docs && mike deploy --push --template templates/redirect.html --update-aliases $VERSION latest
+            - run: cd docs && mike set-default --push --template templates/redirect.html latest

--- a/docs/templates/redirect.html
+++ b/docs/templates/redirect.html
@@ -9,7 +9,7 @@
     </noscript>
     <script>
         window.location.replace(
-            "{{href}}" + window.location.search + window.location.hash
+            "{{href}}" + window.location.search + window.location.hash  // nosemgrep
         );
     </script>
 
@@ -28,7 +28,7 @@
 </head>
 
 <body>
-    Redirecting to <a href="{{href}}">{{href}}</a>...
+    Redirecting to <a href="{{href}}">{{href}}</a>...  <!-- nosemgrep -->
 </body>
 
 </html>

--- a/docs/templates/redirect.html
+++ b/docs/templates/redirect.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <title>Redirecting</title>
+    <noscript>
+        <meta http-equiv="refresh" content="1; url={{href}}" />
+    </noscript>
+    <script>
+        window.location.replace(
+            "{{href}}" + window.location.search + window.location.hash
+        );
+    </script>
+
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="FastStream" />
+    <meta property="og:description" content="FastStream Python messaging framework documentation" />
+    <meta property="og:url" content="https://faststream.airt.ai/latest/" />
+    <meta property="og:image" content="https://opengraph.githubassets.com/1671805243.560327/airtai/faststream" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="FastStream" />
+    <meta name="twitter:description" content="FastStream Python messaging framework documentation" />
+    <meta name="twitter:image" content="https://opengraph.githubassets.com/1671805243.560327/airtai/faststream" />
+</head>
+
+<body>
+    Redirecting to <a href="{{href}}">{{href}}</a>...
+</body>
+
+</html>


### PR DESCRIPTION
# Description

Use redirect template with mike inorder to eliminate tampering index.html to add meta tags.
Redirect template is taken from https://github.com/jimporter/mike/blob/master/mike/templates/redirect.html.

Fixes #807 

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] My changes do not generate any new warnings
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-anaylysis.sh`
