### PR TITLE
Push mike docs once instead of twice

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -29,5 +29,5 @@ jobs:
                 git config --local user.name "github-actions[bot]"
             - run: echo $VERSION
             # - run: cd docs && mike delete --all
-            - run: cd docs && mike deploy --push --template templates/redirect.html --update-aliases $VERSION latest
+            - run: cd docs && mike deploy --template templates/redirect.html --update-aliases $VERSION latest
             - run: cd docs && mike set-default --push --template templates/redirect.html latest


### PR DESCRIPTION
# Description

Bug: Push mike docs once instead of twice
Caught by @harishmohanraj 

Fixes #816 

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] My changes do not generate any new warnings
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-anaylysis.sh`
