### PR TITLE
fix: ImportError: typing 'override' from 'faststream._compat' (python 3.12)

### DIFF
--- a/faststream/_compat.py
+++ b/faststream/_compat.py
@@ -17,6 +17,7 @@ if sys.version_info < (3, 12):
     from typing_extensions import override as override
 else:
     from typing import TypedDict as TypedDict
+    from typing import override as override
 
 if sys.version_info < (3, 11):
     from typing_extensions import Never as Never


### PR DESCRIPTION
# Description

Added import for the override function (python 3.12)
`from typing import override as override`

Fixes # (issue number)

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [X] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [ ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-anaylysis.sh`
- [ ] I have included code examples to illustrate the modifications
