### PR TITLE
chore: change PyPi publish trigger

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -1,11 +1,9 @@
 name: Publish to PyPi
 
 on:
-  workflow_run:
-    workflows: [Test]
-    types: [completed]
-    branches:
-      - main
+  push:
+    tags:
+      - "*"
 
 jobs:
   publish:


### PR DESCRIPTION
Mv PyPI publish trigger from "successful tests" to publish on manual GitHub Release creation