### PR TITLE
Add workflow to update release notes automatically

### DIFF
--- a/.github/workflows/update_release_notes.yaml
+++ b/.github/workflows/update_release_notes.yaml
@@ -1,0 +1,50 @@
+name: Update Release Notes
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  update-release-notes:
+    runs-on: ubuntu-latest
+    permissions:
+        contents: write
+    env:
+      TAG_NAME: ${{ github.ref_name }}
+      BRANCH_NAME: update-release-notes-${{ github.ref_name }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: 'main'
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run update_releases.py script
+        run: python ./docs/update_releases.py
+
+      - name: Check for changes
+        id: git-check
+        run: |
+          git diff --quiet || echo "::set-output name=changes_detected::true"
+
+      - name: Show git diff
+        run: git diff
+      - name: Create new branch and commit changes if there are any
+        if: steps.git-check.outputs.changes_detected
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "Update release notes for ${{ env.TAG_NAME }}"
+          branch: main
+          file_pattern: docs/docs/en/release.md
+          commit_user_name: 'github-actions'
+          commit_user_email: 'github-actions@github.com'


### PR DESCRIPTION
# Description

For new tag, this workflow automatically gets triggered, runs the update_releases.py and commits the changes straight to main. 

My initial idea was to create a new branch, add changes to that commit and create a new pull request. Similar to what dependabot does right now. I wrote an initial version at my fork [here](https://github.com/kumaranvpl/faststream/blob/915a316be0ff2e869646d7d59a66282c136800bb/.github/workflows/update_release_notes.yaml). But for some reason I couldn't get it to work. It creates a new branch but that branch does not has the updated release notes. 

After trying to fix it for some time, I gave up and reverted to just pushing the changes to main itself.

Fixes #990 


