### PR TITLE
Debug Module Name in NATS Example

### DIFF
--- a/docs/includes/getting_started/context/existed_annotations.md
+++ b/docs/includes/getting_started/context/existed_annotations.md
@@ -40,7 +40,7 @@
 
 === "NATS"
     ```python
-    from faststream.rabbit.annotations import (
+    from faststream.nats.annotations import (
         Logger, ContextRepo, NatsMessage,
         NatsBroker, NatsProducer, NatsJsProducer,
         Client, JsClient,


### PR DESCRIPTION
# Description

In the Document([Here](https://faststream.airt.ai/0.2/getting-started/context/existed/#annotated-aliases)) Fixed Module Name to `nats`.