### PR TITLE
docs: fix misspelled FastDepends reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ The availability of such documentation significantly simplifies the integration 
 
 ## Dependencies
 
-**FastStream** (thanks to [**FastDepend**](https://lancetnik.github.io/FastDepends/)) has a dependency management system similar to `pytest fixtures` and `FastAPI Depends` at the same time. Function arguments declare which dependencies you want are needed, and a special decorator delivers them from the global Context object.
+**FastStream** (thanks to [**FastDepends**](https://lancetnik.github.io/FastDepends/)) has a dependency management system similar to `pytest fixtures` and `FastAPI Depends` at the same time. Function arguments declare which dependencies you want are needed, and a special decorator delivers them from the global Context object.
 
 ```python
 from faststream import Depends, Logger


### PR DESCRIPTION
# Description

Fixes misspelled FastDepends library reference in README.md)

## Type of change

Please delete options that are not relevant.

- [X] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [X] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [X] I have conducted a self-review of my own code
- [X] I have made the necessary changes to the documentation
- [X] My changes do not generate any new warnings
- [X] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [X] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [X] I have ensured that static analysis tests are passing by running `scripts/static-anaylysis.sh`
- [X] I have included code examples to illustrate the modifications
