### PR TITLE
Add pull_request permission to workflow

### DIFF
--- a/.github/workflows/update_release_notes.yaml
+++ b/.github/workflows/update_release_notes.yaml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
         contents: write
+        pull-requests: write
     env:
       TAG_NAME: ${{ github.ref_name }}
       BRANCH_NAME: update-release-notes-${{ github.ref_name }}


### PR DESCRIPTION
This https://github.com/airtai/faststream/actions/runs/7079359455/job/19266030964 was failing earlier because I missed pull-request permission for workflow. 
I have added it now as a fix.