### PR TITLE
Use Github App to generate token for release notes PR

### DIFF
--- a/.github/workflows/update_release_notes.yaml
+++ b/.github/workflows/update_release_notes.yaml
@@ -20,6 +20,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -45,9 +51,10 @@ jobs:
         if: steps.git-check.outputs.changes_detected
         uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           branch: ${{ env.BRANCH_NAME }}
           title: "Update Release Notes for ${{ env.TAG_NAME }}"
           commit-message: "Update Release Notes for ${{ env.TAG_NAME }}"
           body: "This is an automated pull request to update the release notes for ${{ env.TAG_NAME }}"
           base: "main" # The branch you want to merge into
+          reviewers: davorrunje, Lancetnik, kumaranvpl, sternakt


### PR DESCRIPTION
Whenever we make a new release we create a PR with workflow to update release notes automatically. 

But that is broken right now because we can't trigger further workflows using `GITHUB_TOKEN` - https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs

To fix that, I have created a new GitHub App and using that to generate token as mentioned here - https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#authenticating-with-github-app-generated-tokens

I have also updated the script to request review from bunch of us. This is in order to get a notification mail which serves as a reminder.