### PR TITLE
fix: error import packaging module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dynamic = ["version"]
 dependencies = [
     "anyio>=3.7.1,<4; python_version < '3.11'",
     "anyio>=3.7.1,<5; python_version >= '3.11'",
+    "packaging>=23.2",
     "fast-depends>=2.2.0,<3",
     "typer>=0.9,<1",
     "uvloop>=0.18.0; sys_platform != 'win32' and (sys_platform != 'cygwin' and platform_python_implementation != 'PyPy')",


### PR DESCRIPTION
# Description

An error was found in importing library sides, on (version faststream **0.3.4** **0.3.5**)

```bash
Traceback (most recent call last):
  File "/usr/local/bin/faststream", line 5, in <module>
    from faststream.__main__ import cli
  File "/usr/local/lib/python3.12/site-packages/faststream/__init__.py", line 1, in <module>
    from faststream.annotations import ContextRepo, Logger, NoCast
  File "/usr/local/lib/python3.12/site-packages/faststream/annotations.py", line 4, in <module>
    from faststream._compat import Annotated
  File "/usr/local/lib/python3.12/site-packages/faststream/_compat.py", line 12, in <module>
    from packaging.version import parse
ModuleNotFoundError: No module named 'packaging'
```

Fixes # (issue number)

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [x] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [ ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-anaylysis.sh`
- [ ] I have included code examples to illustrate the modifications
