### PR TITLE
Increase rate limit and max connections

### DIFF
--- a/.github/workflows/check-broken-links-in-docs.yaml
+++ b/.github/workflows/check-broken-links-in-docs.yaml
@@ -15,5 +15,5 @@ jobs:
         uses: ruzickap/action-my-broken-link-checker@v2
         with:
           url: https://faststream.airt.ai
-          cmd_params: '--buffer-size=8192 --max-connections=10 --color=always --header="User-Agent:curl/7.54.0" --exclude="(localhost:8000|linkedin.com|fonts.gstatic.com)" --max-connections-per-host=5 --rate-limit=5'
+          cmd_params: '--buffer-size=8192 --max-connections=1 --color=always --header="User-Agent:Mozilla/5.0(Firefox/97.0)" --exclude="(localhost:8000|linkedin.com|fonts.gstatic.com|reddit.com)" --max-connections-per-host=1 --rate-limit=1'
           debug: true


### PR DESCRIPTION
* Use mozilla's user agent instead of curl's user agent
* Ignore reddit links as it blocks the crawlers/bots
* Reduce max connections, rate limit to prevent 429 - too many requests error code from github