### PR TITLE
fix (#1100): FastAPI 0.106 compatibility

### DIFF
--- a/docs/docs/en/nats/examples/direct.md
+++ b/docs/docs/en/nats/examples/direct.md
@@ -15,9 +15,7 @@ a `subject` sends messages to all consumers subscribed to it.
 
 ## Scaling
 
-If one `subject` is being listened to by several consumers with the same `queue group`, the message will go to a random consumer each time.
-
-Thus, *NATS* can independently balance the load on queue consumers. You can increase the processing speed of the message flow from the queue by simply launching additional instances of the consumer service. You don't need to make changes to the current infrastructure configuration: *NATS* will take care of how to distribute messages between your services.
+{! includes/en/nats/scaling.md !}
 
 ## Example
 

--- a/docs/docs/en/nats/examples/pattern.md
+++ b/docs/docs/en/nats/examples/pattern.md
@@ -14,9 +14,7 @@ search:
 
 ## Scaling
 
-If one `subject` is being listened to by several consumers with the same `queue group`, the message will go to a random consumer each time.
-
-Thus, *NATS* can independently balance the load on queue consumers. You can increase the processing speed of the message flow from the queue by simply launching additional instances of the consumer service. You don't need to make changes to the current infrastructure configuration: *NATS* will take care of how to distribute messages between your services.
+{! includes/en/nats/scaling.md !}
 
 ## Example
 

--- a/docs/includes/en/nats/scaling.md
+++ b/docs/includes/en/nats/scaling.md
@@ -1,0 +1,8 @@
+If one `subject` is being listened to by several consumers with the same `queue group`, the message will go to a random consumer each time.
+
+Thus, *NATS* can independently balance the load on queue consumers. You can increase the processing speed of the message flow from the queue by simply launching additional instances of the consumer service. You don't need to make changes to the current infrastructure configuration: *NATS* will take care of how to distribute messages between your services.
+
+!!! tip
+    By defaul, all subscribers are consuming messages from subject in blocking mode. You can't process multiple messages from the same subject in the same time. So, you have some kind of block per subject.
+
+    But, all `NatsBroker` subscribers has `max_workers` argument allows you to consume messages in a per-subscriber pool. So, if you have subscriber like `#!python @broker.subscriber(..., max_workers=10)`, it means that you can process up to **10** by it in the same time.

--- a/faststream/__about__.py
+++ b/faststream/__about__.py
@@ -1,5 +1,5 @@
 """Simple and fast framework to create message brokers based microservices."""
-__version__ = "0.3.10"
+__version__ = "0.3.11"
 
 
 INSTALL_YAML = """

--- a/faststream/_compat.py
+++ b/faststream/_compat.py
@@ -79,6 +79,7 @@ try:
 
     major, minor, *_ = map(int, FASTAPI_VERSION.split("."))
     FASTAPI_V2 = major > 0 or minor > 100
+    FASTAPI_V106 = major > 0 or minor > 106
 
     if FASTAPI_V2:
         from fastapi._compat import _normalize_errors

--- a/faststream/_compat.py
+++ b/faststream/_compat.py
@@ -79,7 +79,7 @@ try:
 
     major, minor, *_ = map(int, FASTAPI_VERSION.split("."))
     FASTAPI_V2 = major > 0 or minor > 100
-    FASTAPI_V106 = major > 0 or minor > 106
+    FASTAPI_V106 = major > 0 or minor >= 106
 
     if FASTAPI_V2:
         from fastapi._compat import _normalize_errors

--- a/faststream/broker/fastapi/route.py
+++ b/faststream/broker/fastapi/route.py
@@ -291,7 +291,7 @@ def get_app(
                 body=request._body,
                 dependant=dependant,
                 dependency_overrides_provider=dependency_overrides_provider,
-                **kwargs,
+                **kwargs,  # type: ignore[arg-type]
             )
 
             values, errors, _, _2, _3 = solved_result

--- a/faststream/broker/fastapi/route.py
+++ b/faststream/broker/fastapi/route.py
@@ -27,7 +27,7 @@ from fastapi.routing import run_endpoint_function
 from starlette.requests import Request
 from starlette.routing import BaseRoute
 
-from faststream._compat import raise_fastapi_validation_error
+from faststream._compat import FASTAPI_V106, raise_fastapi_validation_error
 from faststream.broker.core.asyncronous import BrokerAsyncUsecase
 from faststream.broker.message import StreamMessage as NativeMessage
 from faststream.broker.schemas import NameRequired
@@ -44,7 +44,6 @@ class StreamRoute(BaseRoute, Generic[MsgType, P_HandlerParams, T_HandlerReturn])
         path : path of the route
         broker : BrokerAsyncUsecase object representing the broker for the route
         dependant : Dependable object representing the dependencies for the route
-
     """
 
     handler: HandlerCallWrapper[MsgType, P_HandlerParams, T_HandlerReturn]
@@ -75,7 +74,6 @@ class StreamRoute(BaseRoute, Generic[MsgType, P_HandlerParams, T_HandlerReturn])
 
         Returns:
             None.
-
         """
         self.path = path or ""
         self.broker = broker
@@ -136,7 +134,6 @@ class StreamMessage(Request):
     Methods:
         __init__ : initializes the StreamMessage object
         get_session : returns a callable function that handles the session of the message
-
     """
 
     scope: AnyDict
@@ -194,7 +191,6 @@ class StreamMessage(Request):
 
         Note:
             This function is used to create a session for handling requests. It takes a dependant object, which represents the session, and a dependency overrides provider, which allows for overriding dependencies. It returns a callable that takes a native message and returns an awaitable sendable message. The session is created based on the dependant object and the message passed to the callable. The session is then used to call the function obtained from the dependant object, and the result is returned.
-
         """
         assert dependant.call  # nosec B101
 
@@ -257,7 +253,7 @@ class StreamMessage(Request):
 def get_app(
     dependant: Dependant,
     dependency_overrides_provider: Optional[Any] = None,
-) -> Callable[[StreamMessage], Coroutine[Any, Any, SendableMessage]]:
+) -> Callable[[StreamMessage], Coroutine[Any, Any, SendableMessage],]:
     """Creates a FastAPI application.
 
     Args:
@@ -269,7 +265,6 @@ def get_app(
 
     Raises:
         AssertionError: If the code reaches an unreachable state.
-
     """
 
     async def app(request: StreamMessage) -> SendableMessage:
@@ -283,16 +278,20 @@ def get_app(
 
         Raises:
             AssertionError: If the code reaches an unreachable point.
-
         """
         async with AsyncExitStack() as stack:
-            request.scope["fastapi_astack"] = stack
+            if FASTAPI_V106:
+                kwargs = {"async_exit_stack": stack}
+            else:
+                request.scope["fastapi_astack"] = stack
+                kwargs = {}
 
             solved_result = await solve_dependencies(
                 request=request,
                 body=request._body,
                 dependant=dependant,
                 dependency_overrides_provider=dependency_overrides_provider,
+                **kwargs,
             )
 
             values, errors, _, _2, _3 = solved_result

--- a/faststream/nats/broker.py
+++ b/faststream/nats/broker.py
@@ -314,6 +314,7 @@ class NatsBroker(
         middlewares: Optional[Sequence[Callable[[Msg], BaseMiddleware]]] = None,
         filter: Filter[NatsMessage] = default_filter,
         no_ack: bool = False,
+        max_workers: int = 1,
         # AsyncAPI information
         title: Optional[str] = None,
         description: Optional[str] = None,
@@ -394,6 +395,7 @@ class NatsBroker(
                 description=description,
                 include_in_schema=include_in_schema,
                 graceful_timeout=self.graceful_timeout,
+                max_workers=max_workers,
                 log_context_builder=partial(
                     self._get_log_context,
                     stream=stream.name if stream else "",

--- a/faststream/nats/broker.pyi
+++ b/faststream/nats/broker.pyi
@@ -233,8 +233,8 @@ class NatsBroker(
         pending_bytes_limit: Optional[int] = None,
         # Core arguments
         max_msgs: int = 0,
-        ack_first: bool = False,
         # JS arguments
+        ack_first: bool = False,
         stream: Union[str, JStream, None] = None,
         durable: Optional[str] = None,
         config: Optional[api.ConsumerConfig] = None,
@@ -254,6 +254,7 @@ class NatsBroker(
         filter: Filter[NatsMessage] = default_filter,
         retry: bool = False,
         no_ack: bool = False,
+        max_workers: int = 1,
         # AsyncAPI information
         title: Optional[str] = None,
         description: Optional[str] = None,

--- a/faststream/nats/handler.py
+++ b/faststream/nats/handler.py
@@ -92,7 +92,7 @@ class LogicNatsHandler(AsyncHandler[Msg]):
             Doc("AsyncAPI subscriber title"),
         ] = None,
         include_in_schema: Annotated[
-            Optional[str],
+            bool,
             Doc("Whether to include the handler in AsyncAPI schema"),
         ] = True,
     ) -> None:
@@ -145,13 +145,13 @@ class LogicNatsHandler(AsyncHandler[Msg]):
         )
 
     @override
-    async def start(
+    async def start(  # type: ignore[override]
         self,
         connection: Annotated[
             Union[Client, JetStreamContext],
             Doc("NATS client or JS Context object using to create subscription"),
         ],
-    ) -> None:  # type: ignore[override]
+    ) -> None:
         """Create NATS subscription and start consume task."""
         if self.pull_sub is not None:
             connection = cast(JetStreamContext, connection)
@@ -240,7 +240,7 @@ class LogicNatsHandler(AsyncHandler[Msg]):
 
     async def __consume_msg(
         self,
-        msg: Union[Msg, List[Msg]],
+        msg: Msg,
     ) -> None:
         """Proxy method to call `self.consume` with semaphore block."""
         async with self.limiter:

--- a/faststream/nats/handler.py
+++ b/faststream/nats/handler.py
@@ -118,7 +118,7 @@ class LogicNatsHandler(AsyncHandler[Msg]):
         self.max_workers = max_workers
         self.subscription = None
 
-        self.send_stream, self.receive_stream = anyio.create_memory_object_stream[Msg](
+        self.send_stream, self.receive_stream = anyio.create_memory_object_stream(
             max_buffer_size=max_workers
         )
         self.limiter = anyio.Semaphore(max_workers)

--- a/faststream/nats/handler.py
+++ b/faststream/nats/handler.py
@@ -1,15 +1,18 @@
 import asyncio
 from contextlib import suppress
-from typing import Any, Callable, Dict, Optional, Sequence, Union, cast
+from typing import Any, Callable, Dict, List, Optional, Sequence, Union, cast
 
+import anyio
+from anyio.abc import TaskGroup, TaskStatus
 from fast_depends.core import CallModel
 from nats.aio.client import Client
 from nats.aio.msg import Msg
 from nats.aio.subscription import Subscription
 from nats.errors import TimeoutError
 from nats.js import JetStreamContext
+from typing_extensions import Doc
 
-from faststream._compat import override
+from faststream._compat import Annotated, override
 from faststream.broker.handler import AsyncHandler
 from faststream.broker.message import StreamMessage
 from faststream.broker.middlewares import BaseMiddleware
@@ -39,36 +42,61 @@ class LogicNatsHandler(AsyncHandler[Msg]):
         JetStreamContext.PushSubscription,
         JetStreamContext.PullSubscription,
     ]
-    task: Optional["asyncio.Task[Any]"] = None
+    task_group: Optional[TaskGroup]
+    task: Optional["asyncio.Task[Any]"]
 
     def __init__(
         self,
-        subject: str,
-        log_context_builder: Callable[[StreamMessage[Any]], Dict[str, str]],
-        queue: str = "",
-        stream: Optional[JStream] = None,
-        pull_sub: Optional[PullSub] = None,
-        extra_options: Optional[AnyDict] = None,
-        graceful_timeout: Optional[float] = None,
+        subject: Annotated[
+            str,
+            Doc("NATS subject to subscribe"),
+        ],
+        log_context_builder: Annotated[
+            Callable[[StreamMessage[Any]], Dict[str, str]],
+            Doc("Function to create log extra data by message"),
+        ],
+        queue: Annotated[
+            str,
+            Doc("NATS queue name"),
+        ] = "",
+        stream: Annotated[
+            Optional[JStream],
+            Doc("NATS Stream object"),
+        ] = None,
+        pull_sub: Annotated[
+            Optional[PullSub],
+            Doc("NATS Pull consumer parameters container"),
+        ] = None,
+        extra_options: Annotated[
+            Optional[AnyDict],
+            Doc("Extra arguments for subscription creation"),
+        ] = None,
+        graceful_timeout: Annotated[
+            Optional[float],
+            Doc(
+                "Wait up to this time (if setted up) in graceful shutdown mode. "
+                "Kills task forcely if expired."
+            ),
+        ] = None,
+        max_workers: Annotated[
+            int,
+            Doc("Process up to this parameter messages concurently"),
+        ] = 1,
         # AsyncAPI information
-        description: Optional[str] = None,
-        title: Optional[str] = None,
-        include_in_schema: bool = True,
+        description: Annotated[
+            Optional[str],
+            Doc("AsyncAPI subscriber description"),
+        ] = None,
+        title: Annotated[
+            Optional[str],
+            Doc("AsyncAPI subscriber title"),
+        ] = None,
+        include_in_schema: Annotated[
+            Optional[str],
+            Doc("Whether to include the handler in AsyncAPI schema"),
+        ] = True,
     ) -> None:
-        """Initialize the NATS handler.
-
-        Args:
-            subject: The NATS subject.
-            log_context_builder: The log context builder.
-            queue: The NATS queue.
-            stream: The NATS stream.
-            pull_sub: The NATS pull subscription.
-            extra_options: The extra options.
-            graceful_timeout: The graceful timeout.
-            description: The description.
-            title: The title.
-            include_in_schema: Whether to include the handler in the schema.
-        """
+        """Initialize the NATS handler."""
         reg, path = compile_path(subject, replace_symbol="*")
         self.subject = path
         self.path_regex = reg
@@ -87,8 +115,14 @@ class LogicNatsHandler(AsyncHandler[Msg]):
             graceful_timeout=graceful_timeout,
         )
 
-        self.task = None
+        self.max_workers = max_workers
         self.subscription = None
+
+        self.send_stream, self.receive_stream = anyio.create_memory_object_stream[Msg](
+            max_buffer_size=max_workers
+        )
+        self.limiter = anyio.Semaphore(max_workers)
+        self.task = None
 
     def add_call(
         self,
@@ -111,7 +145,14 @@ class LogicNatsHandler(AsyncHandler[Msg]):
         )
 
     @override
-    async def start(self, connection: Union[Client, JetStreamContext]) -> None:  # type: ignore[override]
+    async def start(
+        self,
+        connection: Annotated[
+            Union[Client, JetStreamContext],
+            Doc("NATS client or JS Context object using to create subscription"),
+        ],
+    ) -> None:  # type: ignore[override]
+        """Create NATS subscription and start consume task."""
         if self.pull_sub is not None:
             connection = cast(JetStreamContext, connection)
 
@@ -122,19 +163,26 @@ class LogicNatsHandler(AsyncHandler[Msg]):
                 subject=self.subject,
                 **self.extra_options,
             )
-            self.task = asyncio.create_task(self._consume())
+            self.task = asyncio.create_task(self._consume_pull())
 
         else:
+            if self.max_workers > 1:
+                self.task = asyncio.create_task(self._serve_consume_queue())
+                cb = self.__put_msg
+            else:
+                cb = self.consume
+
             self.subscription = await connection.subscribe(
                 subject=self.subject,
                 queue=self.queue,
-                cb=self.consume,  # type: ignore[arg-type]
+                cb=cb,  # type: ignore[arg-type]
                 **self.extra_options,
             )
 
         await super().start()
 
     async def close(self) -> None:
+        """Clean up handler subscription, cancel consume task in graceful mode."""
         await super().close()
 
         if self.subscription is not None:
@@ -145,10 +193,19 @@ class LogicNatsHandler(AsyncHandler[Msg]):
             self.task.cancel()
             self.task = None
 
-    async def _consume(self) -> None:
+    async def _consume_pull(
+        self,
+        *,
+        task_status: TaskStatus[None] = anyio.TASK_STATUS_IGNORED,
+    ) -> None:
+        """Endless task consuming messages using NATS Pull subscriber."""
         assert self.pull_sub  # nosec B101
 
         sub = cast(JetStreamContext.PullSubscription, self.subscription)
+
+        cb = self.__consume_msg if self.max_workers > 1 else self.consume
+
+        task_status.started()
 
         while self.running:  # pragma: no branch
             with suppress(TimeoutError), self.lock:
@@ -160,9 +217,46 @@ class LogicNatsHandler(AsyncHandler[Msg]):
                 if messages:
                     if self.pull_sub.batch:
                         await self.consume(messages)  # type: ignore[arg-type]
+
                     else:
-                        await asyncio.gather(*map(self.consume, messages))
+                        async with anyio.create_task_group() as tg:
+                            for msg in messages:
+                                tg.start_soon(cb, msg)
+
+    async def _serve_consume_queue(
+        self,
+        *,
+        task_status: TaskStatus[None] = anyio.TASK_STATUS_IGNORED,
+    ) -> None:
+        """Endless task consuming messages from in-memory queue.
+
+        Suitable to batch messages by amount, timestamps, etc and call `consume` for this batches.
+        """
+        async with anyio.create_task_group() as tg:
+            task_status.started()
+
+            async for msg in self.receive_stream:
+                tg.start_soon(self.__consume_msg, msg)
+
+    async def __consume_msg(
+        self,
+        msg: Union[Msg, List[Msg]],
+    ) -> None:
+        """Proxy method to call `self.consume` with semaphore block."""
+        async with self.limiter:
+            await self.consume(msg)
+
+    async def __put_msg(self, msg: Msg) -> None:
+        """Proxy method to put msg into in-memory queue with semaphore block."""
+        async with self.limiter:
+            await self.send_stream.send(msg)
 
     @staticmethod
-    def get_routing_hash(subject: str) -> str:
+    def get_routing_hash(
+        subject: Annotated[str, Doc("NATS subject to consume messages")],
+    ) -> str:
+        """Get handler hash by outer data.
+
+        Using to find handler in `broker.handlers` dictionary.
+        """
         return subject

--- a/faststream/nats/handler.py
+++ b/faststream/nats/handler.py
@@ -1,9 +1,10 @@
 import asyncio
 from contextlib import suppress
-from typing import Any, Callable, Dict, List, Optional, Sequence, Union, cast
+from typing import Any, Callable, Dict, Optional, Sequence, Union, cast
 
 import anyio
 from anyio.abc import TaskGroup, TaskStatus
+from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from fast_depends.core import CallModel
 from nats.aio.client import Client
 from nats.aio.msg import Msg
@@ -44,6 +45,8 @@ class LogicNatsHandler(AsyncHandler[Msg]):
     ]
     task_group: Optional[TaskGroup]
     task: Optional["asyncio.Task[Any]"]
+    send_stream: MemoryObjectSendStream[Msg]
+    receive_stream: MemoryObjectReceiveStream[Msg]
 
     def __init__(
         self,

--- a/faststream/utils/context/repository.py
+++ b/faststream/utils/context/repository.py
@@ -1,12 +1,10 @@
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from inspect import _empty
-from typing import Any, Dict, Iterator, Mapping, TypeVar
+from typing import Any, Dict, Iterator, Mapping
 
 from faststream.types import AnyDict
 from faststream.utils.classes import Singleton
-
-T = TypeVar("T")
 
 __all__ = ("ContextRepo", "context")
 
@@ -50,7 +48,7 @@ class ContextRepo(Singleton):
         """
         self._global_context.pop(key, None)
 
-    def set_local(self, key: str, value: T) -> "Token[T]":
+    def set_local(self, key: str, value: Any) -> "Token[Any]":
         """Set a local context variable.
 
         Args:
@@ -170,4 +168,4 @@ class ContextRepo(Singleton):
             self.reset_local(key, token)
 
 
-context: ContextRepo = ContextRepo()
+context = ContextRepo()

--- a/faststream/utils/functions.py
+++ b/faststream/utils/functions.py
@@ -118,7 +118,7 @@ def timeout_scope(
     raise_timeout: bool = False,
 ) -> ContextManager[anyio.CancelScope]:
     scope: Callable[[Optional[float]], ContextManager[anyio.CancelScope]]
-    scope = anyio.fail_after if raise_timeout else anyio.move_on_after
+    scope = anyio.fail_after if raise_timeout else anyio.move_on_after  # type: ignore[assignment]
 
     return scope(timeout)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ lint = [
     "types-redis",
     "types-Pygments",
     "types-docutils",
-    "mypy==1.7.1",
+    "mypy==1.8.0",
     "ruff==0.1.8",
     "pyupgrade-directories==0.3.0",
     "bandit==1.7.6",

--- a/tests/asyncapi/base/naming.py
+++ b/tests/asyncapi/base/naming.py
@@ -1,4 +1,4 @@
-from typing import Type
+from typing import Any, Type
 
 from dirty_equals import IsStr
 from pydantic import create_model
@@ -9,7 +9,7 @@ from faststream.broker.core.abc import BrokerUsecase
 
 
 class BaseNaming:  # noqa: D101
-    broker_class: Type[BrokerUsecase]
+    broker_class: Type[BrokerUsecase[Any, Any]]
 
 
 class SubscriberNaming(BaseNaming):  # noqa: D101


### PR DESCRIPTION
# Description

* FastAPI "0.106+" compatibility
* NATS `max_workers` option
  ```python
  @nats_broker(..., max_workers=10)
  async def handler(...):
      """
      Consumes messages from subject concurently in the pool
      (up to 10 messages in the same time)
      """
  ```

Fixes #1100, close #1099

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [x] Bug fix (a non-breaking change that resolves an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-anaylysis.sh`
- [ ] I have included code examples to illustrate the modifications
