### PR TITLE
Fix bug - using old upload-artifact version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -242,7 +242,7 @@ jobs:
           COVERAGE_FILE: coverage/.coverage.confluent-py
           CONTEXT: confluent-py
       - name: Store coverage files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: .coverage.confluent-py
           path: coverage


### PR DESCRIPTION
# Description

I was using old v3 version of upload-artifact instead of latest version v4. 
Because of this coverage of confluent tests were uploaded to somewhere else and not included in `coverage combine`.

Fixed the mistake and updated upload-artifact to v4. Now coverage is 98% - https://github.com/airtai/faststream/actions/runs/7708185439/job/21006946331