### PR TITLE
Comment out retry and timeout in a confluent test

### DIFF
--- a/tests/brokers/confluent/test_parser.py
+++ b/tests/brokers/confluent/test_parser.py
@@ -9,7 +9,7 @@ from faststream.confluent import KafkaBroker
 
 
 @pytest.mark.asyncio()
-@pytest.mark.flaky(reruns=3, reruns_delay=1)
+# @pytest.mark.flaky(reruns=3, reruns_delay=1)
 class LocalCustomParserTestcase:  # noqa: D101
     broker_class: Type[BrokerAsyncUsecase]
 
@@ -119,7 +119,7 @@ class LocalCustomParserTestcase:  # noqa: D101
             assert event.is_set()
             mock.assert_called_once_with(b"hello")
 
-    @pytest.mark.timeout(20)
+    # @pytest.mark.timeout(20)
     async def test_local_parser_no_share_between_subscribers(
         self,
         event: asyncio.Event,


### PR DESCRIPTION
# Description

`test_local_parser_no_share_between_subscribers` is one of the test which had getting stuck issue when retry happened.

I have ran the problematic test tens of times in my local if not a hundred times. Timout and retry is not happening anymore after merging - https://github.com/airtai/faststream/pull/1193. 

So, commenting out the timeout and retry flags.

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [ ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-anaylysis.sh`
- [ ] I have included code examples to illustrate the modifications
