### PR TITLE
Add a CI job to check for missed docs changes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,6 +40,26 @@ jobs:
         shell: bash
         run: semgrep scan --config auto --error
 
+  check-docs-changes:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: pyproject.toml
+      - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: pip install -e ".[dev]"
+      - name: Run build docs
+        run: bash scripts/build-docs.sh
+      - name: Check for changes
+        id: git-diff
+        run: git diff --exit-code
+
   test:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
@@ -458,6 +478,7 @@ jobs:
 
     needs:
       - static_analysis
+      - check-docs-changes
       - coverage-combine
       - test-macos-latest
       - test-windows-latest


### PR DESCRIPTION
# Description

I have added a new CI job which runs build-docs.sh script and checks for changes using `git diff` command. 

Fixes #1202 

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [ ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-anaylysis.sh`
- [ ] I have included code examples to illustrate the modifications
