### PR TITLE
feat (#1235): StreamSub maxlen parameter

### DIFF
--- a/faststream/redis/producer.py
+++ b/faststream/redis/producer.py
@@ -91,6 +91,7 @@ class RedisFastProducer:
         rpc: bool = False,
         rpc_timeout: Optional[float] = 30.0,
         raise_timeout: bool = False,
+        maxlen: Optional[int] = None,
     ) -> Optional[Any]:
         if not any((channel, list, stream)):
             raise ValueError(INCORRECT_SETUP_MSG)
@@ -116,7 +117,11 @@ class RedisFastProducer:
         elif list is not None:
             await self._connection.rpush(list, msg)
         elif stream is not None:
-            await self._connection.xadd(stream, {DATA_KEY: msg})
+            await self._connection.xadd(
+                name=stream,
+                fields={DATA_KEY: msg},
+                maxlen=maxlen,
+            )
         else:
             raise AssertionError("unreachable")
 

--- a/faststream/redis/publisher.py
+++ b/faststream/redis/publisher.py
@@ -63,6 +63,7 @@ class LogicPublisher(BasePublisher[AnyRedisDict]):
                 channel=getattr(channel, "name", None),
                 list=getattr(list, "name", None),
                 stream=getattr(stream, "name", None),
+                maxlen=getattr(stream, "maxlen", None),
                 reply_to=reply_to or self.reply_to,
                 correlation_id=correlation_id,
                 headers=headers_to_send,

--- a/faststream/redis/schemas.py
+++ b/faststream/redis/schemas.py
@@ -102,6 +102,7 @@ class StreamSub(NameRequired):
     batch: bool = False
     no_ack: bool = False
     last_id: str = "$"
+    maxlen: Optional[PositiveInt] = None
 
     def __init__(
         self,
@@ -112,6 +113,7 @@ class StreamSub(NameRequired):
         batch: bool = False,
         no_ack: bool = False,
         last_id: Optional[str] = None,
+        maxlen: Optional[PositiveInt] = None,
     ) -> None:
         """Redis Stream subscriber parameters.
 
@@ -123,6 +125,7 @@ class StreamSub(NameRequired):
             batch: (bool): consume messages in batches.
             no_ack: (bool): do not add message to PEL.
             last_id: (str | None): start reading from this ID.
+            maxlen: (int | None): truncate old stream members beyond this size.
         """
         if (group and not consumer) or (not group and consumer):
             raise ValueError("You should specify `group` and `consumer` both")
@@ -151,6 +154,7 @@ class StreamSub(NameRequired):
             batch=batch,
             no_ack=no_ack,
             last_id=last_id or "$",
+            maxlen=maxlen,
         )
 
     def __hash__(self) -> int:

--- a/faststream/redis/test.py
+++ b/faststream/redis/test.py
@@ -75,6 +75,7 @@ class FakeProducer(RedisFastProducer):
         rpc: bool = False,
         rpc_timeout: Optional[float] = 30.0,
         raise_timeout: bool = False,
+        maxlen: Optional[int] = None,
     ) -> Optional[Any]:
         any_of = channel or list or stream
         if any_of is None:

--- a/tests/brokers/redis/test_publish.py
+++ b/tests/brokers/redis/test_publish.py
@@ -1,10 +1,12 @@
 import asyncio
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
+from redis.asyncio import Redis
 
-from faststream.redis import ListSub, RedisBroker
+from faststream.redis import ListSub, RedisBroker, StreamSub
 from tests.brokers.base.publish import BrokerPublishTestcase
+from tests.tools import spy_decorator
 
 
 @pytest.mark.redis()
@@ -93,3 +95,38 @@ class TestPublish(BrokerPublishTestcase):  # noqa: D101
 
         assert event.is_set()
         mock.assert_called_once_with([1, 2, 3])
+
+    async def test_publisher_with_maxlen(
+        self,
+        queue: str,
+        pub_broker: RedisBroker,
+        event: asyncio.Event,
+        mock: MagicMock,
+    ):
+        stream = StreamSub(queue + "resp", maxlen=1)
+
+        @pub_broker.subscriber(stream=queue)
+        @pub_broker.publisher(stream=stream)
+        async def handler(msg):
+            return msg
+
+        @pub_broker.subscriber(stream=stream)
+        async def resp(msg):
+            event.set()
+            mock(msg)
+
+        with patch.object(Redis, "xadd", spy_decorator(Redis.xadd)) as m:
+            async with pub_broker:
+                await pub_broker.start()
+                await asyncio.wait(
+                    (
+                        asyncio.create_task(pub_broker.publish("hi", stream=queue)),
+                        asyncio.create_task(event.wait()),
+                    ),
+                    timeout=3,
+                )
+
+        assert event.is_set()
+        mock.assert_called_once_with("hi")
+
+        assert m.mock.call_args_list[-1].kwargs["maxlen"] == 1


### PR DESCRIPTION
# Description

Allow to specify Redis Stream maxlen option in publisher:

```python
@broker.publisher(stream=StreamSub("Output", max_len=10))
async def on_input_data():
    ....
```

Fixes #1235 

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-anaylysis.sh`
- [ ] I have included code examples to illustrate the modifications
