### PR TITLE
Removed unused pytest dependecy from redis/schemas.py

### DIFF
--- a/faststream/redis/schemas.py
+++ b/faststream/redis/schemas.py
@@ -2,7 +2,6 @@ import warnings
 from typing import Optional, Pattern
 
 from pydantic import Field, PositiveFloat, PositiveInt
-from pytest import OptionGroup
 
 from faststream._compat import PYDANTIC_V2
 from faststream.broker.schemas import NameRequired


### PR DESCRIPTION
# Description

Small fix that removes accidental pytest dependency in `redis/schemas.py`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-anaylysis.sh`
- [ ] I have included code examples to illustrate the modifications
