### PR TITLE
feat: add transaction in AioKafkaFastProducer

### DIFF
--- a/faststream/kafka/producer.py
+++ b/faststream/kafka/producer.py
@@ -150,5 +150,5 @@ class AioKafkaFastProducer:
             AssertionError: If the broker is not connected.
 
         """
-        assert self._producer, NOT_CONNECTED_YET    # nosec B101
+        assert self._producer, NOT_CONNECTED_YET  # nosec B101
         return self._producer.transaction()

--- a/faststream/kafka/producer.py
+++ b/faststream/kafka/producer.py
@@ -2,6 +2,7 @@ from typing import Dict, Optional
 from uuid import uuid4
 
 from aiokafka import AIOKafkaProducer
+from aiokafka.producer.producer import TransactionContext
 
 from faststream.broker.parsers import encode_message
 from faststream.exceptions import NOT_CONNECTED_YET
@@ -138,3 +139,16 @@ class AioKafkaFastProducer:
             )
 
         await self._producer.send_batch(batch, topic, partition=partition)
+
+    async def transaction(self) -> TransactionContext:
+        """Publish messages to a topic or topics within a transaction.
+
+        Returns:
+            TransactionContext
+
+        Raises:
+            AssertionError: If the broker is not connected.
+
+        """
+        assert self._producer, NOT_CONNECTED_YET    # nosec B101
+        return self._producer.transaction()

--- a/faststream/kafka/producer.py
+++ b/faststream/kafka/producer.py
@@ -140,7 +140,7 @@ class AioKafkaFastProducer:
 
         await self._producer.send_batch(batch, topic, partition=partition)
 
-    async def transaction(self) -> TransactionContext:
+    def transaction(self) -> TransactionContext:
         """Publish messages to a topic or topics within a transaction.
 
         Returns:


### PR DESCRIPTION
# Description

The ability to use Kafka transactions by the AioKafkaFastProducer object using an out-of-the-box implementation in aiokafka has been added. Previously published an issue with a request to add such functionality to Faststream.

Fixes [#1237](https://github.com/airtai/faststream/issues/1237)

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-anaylysis.sh`
- [ ] I have included code examples to illustrate the modifications
