### PR TITLE
chore: fixed nats-py version

### DIFF
--- a/faststream/__about__.py
+++ b/faststream/__about__.py
@@ -1,6 +1,6 @@
 """Simple and fast framework to create message brokers based microservices."""
 
-__version__ = "0.4.6"
+__version__ = "0.4.7"
 
 
 INSTALL_YAML = """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ confluent = [
 ]
 
 nats = [
-    "nats-py>=2.3.1,<3.0.0"
+    "nats-py>=2.3.1,<=2.7.0"
 ]
 
 redis = [


### PR DESCRIPTION
`nats-py==2.7.2` doesn't work with out `JStream` pydantic class.
We should fix `nats-py` version until #1287  is closed