### PR TITLE
fix: typer 0.12 exclude

### DIFF
--- a/faststream/__about__.py
+++ b/faststream/__about__.py
@@ -1,6 +1,6 @@
 """Simple and fast framework to create message brokers based microservices."""
 
-__version__ = "0.4.7"
+__version__ = "0.4.8"
 
 
 INSTALL_YAML = """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dynamic = ["version"]
 dependencies = [
     "anyio>=3.7.1,<5",
     "fast-depends>=2.4.0b0,<2.5.0",
-    "typer>=0.9,<1",
+    "typer>=0.9,!=0.12,<1",
     "typing-extensions>=4.8.0",
 ]
 


### PR DESCRIPTION
Typer 0.12 looks like a broken release and we doesn't work with it now (but it installs by default). We should exclude this version from requirements and release patch to update FastStream pypi version.