### PR TITLE
fix (#1415): raise SetupError if rpc and reply_to are using in TestCL…

### DIFF
--- a/faststream/nats/testing.py
+++ b/faststream/nats/testing.py
@@ -4,6 +4,7 @@ from nats.aio.msg import Msg
 from typing_extensions import override
 
 from faststream.broker.message import encode_message, gen_cor_id
+from faststream.exceptions import WRONG_PUBLISH_ARGS
 from faststream.nats.broker import NatsBroker
 from faststream.nats.publisher.producer import NatsFastProducer
 from faststream.nats.schemas.js_stream import is_subject_match_wildcard
@@ -71,6 +72,9 @@ class FakeProducer(NatsFastProducer):
         rpc_timeout: Optional[float] = None,
         raise_timeout: bool = False,
     ) -> Any:
+        if rpc and reply_to:
+            raise WRONG_PUBLISH_ARGS
+
         incoming = build_message(
             message=message,
             subject=subject,

--- a/faststream/rabbit/testing.py
+++ b/faststream/rabbit/testing.py
@@ -8,6 +8,7 @@ from pamqp.header import ContentHeader
 from typing_extensions import override
 
 from faststream.broker.message import gen_cor_id
+from faststream.exceptions import WRONG_PUBLISH_ARGS
 from faststream.rabbit.broker.broker import RabbitBroker
 from faststream.rabbit.parser import AioPikaParser
 from faststream.rabbit.publisher.asyncapi import AsyncAPIPublisher
@@ -196,6 +197,9 @@ class FakeProducer(AioPikaFastProducer):
     ) -> Optional[Any]:
         """Publish a message to a RabbitMQ queue or exchange."""
         exch = RabbitExchange.validate(exchange)
+
+        if rpc and reply_to:
+            raise WRONG_PUBLISH_ARGS
 
         incoming = build_message(
             message=message,

--- a/faststream/redis/testing.py
+++ b/faststream/redis/testing.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Optional, Sequence, Union
 from typing_extensions import override
 
 from faststream.broker.message import gen_cor_id
-from faststream.exceptions import SetupError
+from faststream.exceptions import WRONG_PUBLISH_ARGS, SetupError
 from faststream.redis.broker.broker import RedisBroker
 from faststream.redis.message import (
     BatchListMessage,
@@ -87,6 +87,9 @@ class FakeProducer(RedisFastProducer):
         rpc_timeout: Optional[float] = 30.0,
         raise_timeout: bool = False,
     ) -> Optional[Any]:
+        if rpc and reply_to:
+            raise WRONG_PUBLISH_ARGS
+
         correlation_id = correlation_id or gen_cor_id()
 
         body = build_message(

--- a/tests/brokers/nats/test_test_client.py
+++ b/tests/brokers/nats/test_test_client.py
@@ -3,12 +3,23 @@ import asyncio
 import pytest
 
 from faststream import BaseMiddleware
+from faststream.exceptions import SetupError
 from faststream.nats import JStream, NatsBroker, PullSub, TestNatsBroker
 from tests.brokers.base.testclient import BrokerTestclientTestcase
 
 
 @pytest.mark.asyncio()
 class TestTestclient(BrokerTestclientTestcase):
+    async def test_rpc_conflicts_reply(self, broker, queue):
+        async with TestNatsBroker(broker) as br:
+            with pytest.raises(SetupError):
+                await br.publish(
+                    "",
+                    queue,
+                    rpc=True,
+                    reply_to="response",
+                )
+
     @pytest.mark.nats()
     async def test_with_real_testclient(
         self,

--- a/tests/brokers/nats/test_test_client.py
+++ b/tests/brokers/nats/test_test_client.py
@@ -11,7 +11,7 @@ from tests.brokers.base.testclient import BrokerTestclientTestcase
 @pytest.mark.asyncio()
 class TestTestclient(BrokerTestclientTestcase):
     async def test_rpc_conflicts_reply(self, broker, queue):
-        async with TestNatsBroker(broker) as br:
+        async with TestNatsBroker(NatsBroker()) as br:
             with pytest.raises(SetupError):
                 await br.publish(
                     "",

--- a/tests/brokers/nats/test_test_client.py
+++ b/tests/brokers/nats/test_test_client.py
@@ -10,7 +10,7 @@ from tests.brokers.base.testclient import BrokerTestclientTestcase
 
 @pytest.mark.asyncio()
 class TestTestclient(BrokerTestclientTestcase):
-    async def test_rpc_conflicts_reply(self, broker, queue):
+    async def test_rpc_conflicts_reply(self, queue):
         async with TestNatsBroker(NatsBroker()) as br:
             with pytest.raises(SetupError):
                 await br.publish(

--- a/tests/brokers/rabbit/test_test_client.py
+++ b/tests/brokers/rabbit/test_test_client.py
@@ -20,7 +20,7 @@ from tests.brokers.base.testclient import BrokerTestclientTestcase
 @pytest.mark.asyncio()
 class TestTestclient(BrokerTestclientTestcase):
     async def test_rpc_conflicts_reply(self, broker, queue):
-        async with TestRabbitBroker(broker, with_real=False) as br:
+        async with TestRabbitBroker(RabbitBroker()) as br:
             with pytest.raises(SetupError):
                 await br.publish(
                     "",

--- a/tests/brokers/rabbit/test_test_client.py
+++ b/tests/brokers/rabbit/test_test_client.py
@@ -20,7 +20,7 @@ from tests.brokers.base.testclient import BrokerTestclientTestcase
 @pytest.mark.asyncio()
 class TestTestclient(BrokerTestclientTestcase):
     async def test_rpc_conflicts_reply(self, broker, queue):
-        async with TestRabbitBroker(broker) as br:
+        async with TestRabbitBroker(broker, with_real=False) as br:
             with pytest.raises(SetupError):
                 await br.publish(
                     "",

--- a/tests/brokers/rabbit/test_test_client.py
+++ b/tests/brokers/rabbit/test_test_client.py
@@ -19,7 +19,7 @@ from tests.brokers.base.testclient import BrokerTestclientTestcase
 
 @pytest.mark.asyncio()
 class TestTestclient(BrokerTestclientTestcase):
-    async def test_rpc_conflicts_reply(self, broker, queue):
+    async def test_rpc_conflicts_reply(self, queue):
         async with TestRabbitBroker(RabbitBroker()) as br:
             with pytest.raises(SetupError):
                 await br.publish(

--- a/tests/brokers/rabbit/test_test_client.py
+++ b/tests/brokers/rabbit/test_test_client.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 import pytest
 
 from faststream import BaseMiddleware
+from faststream.exceptions import SetupError
 from faststream.rabbit import (
     ExchangeType,
     RabbitBroker,
@@ -18,6 +19,16 @@ from tests.brokers.base.testclient import BrokerTestclientTestcase
 
 @pytest.mark.asyncio()
 class TestTestclient(BrokerTestclientTestcase):
+    async def test_rpc_conflicts_reply(self, broker, queue):
+        async with TestRabbitBroker(broker) as br:
+            with pytest.raises(SetupError):
+                await br.publish(
+                    "",
+                    queue,
+                    rpc=True,
+                    reply_to="response",
+                )
+
     @pytest.mark.rabbit()
     async def test_with_real_testclient(
         self,

--- a/tests/brokers/redis/test_test_client.py
+++ b/tests/brokers/redis/test_test_client.py
@@ -11,7 +11,7 @@ from tests.brokers.base.testclient import BrokerTestclientTestcase
 @pytest.mark.asyncio()
 class TestTestclient(BrokerTestclientTestcase):
     async def test_rpc_conflicts_reply(self, broker, queue):
-        async with TestRedisBroker(broker) as br:
+        async with TestRedisBroker(RedisBroker()) as br:
             with pytest.raises(SetupError):
                 await br.publish(
                     "",

--- a/tests/brokers/redis/test_test_client.py
+++ b/tests/brokers/redis/test_test_client.py
@@ -10,7 +10,7 @@ from tests.brokers.base.testclient import BrokerTestclientTestcase
 
 @pytest.mark.asyncio()
 class TestTestclient(BrokerTestclientTestcase):
-    async def test_rpc_conflicts_reply(self, broker, queue):
+    async def test_rpc_conflicts_reply(self, queue):
         async with TestRedisBroker(RedisBroker()) as br:
             with pytest.raises(SetupError):
                 await br.publish(

--- a/tests/brokers/redis/test_test_client.py
+++ b/tests/brokers/redis/test_test_client.py
@@ -3,12 +3,23 @@ import asyncio
 import pytest
 
 from faststream import BaseMiddleware
+from faststream.exceptions import SetupError
 from faststream.redis import ListSub, RedisBroker, StreamSub, TestRedisBroker
 from tests.brokers.base.testclient import BrokerTestclientTestcase
 
 
 @pytest.mark.asyncio()
 class TestTestclient(BrokerTestclientTestcase):
+    async def test_rpc_conflicts_reply(self, broker, queue):
+        async with TestRedisBroker(broker) as br:
+            with pytest.raises(SetupError):
+                await br.publish(
+                    "",
+                    queue,
+                    rpc=True,
+                    reply_to="response",
+                )
+
     @pytest.mark.redis()
     async def test_with_real_testclient(
         self,


### PR DESCRIPTION
…ient in the same time

# Description

Please include a summary of the change and specify which issue is being addressed. Additionally, provide relevant motivation and context.

Fixes #1415

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [x] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-anaylysis.sh`
- [ ] I have included code examples to illustrate the modifications
