### PR TITLE
feat: add RMQ channels options, support for prefix for routing_key, a…

### DIFF
--- a/faststream/__about__.py
+++ b/faststream/__about__.py
@@ -1,6 +1,6 @@
 """Simple and fast framework to create message brokers based microservices."""
 
-__version__ = "0.5.5"
+__version__ = "0.5.6"
 
 SERVICE_NAME = f"faststream-{__version__}"
 

--- a/faststream/broker/core/abc.py
+++ b/faststream/broker/core/abc.py
@@ -46,6 +46,19 @@ class ABCBroker(Generic[MsgType]):
         self._parser = parser
         self._decoder = decoder
 
+    def add_middleware(self, middleware: "BrokerMiddleware[MsgType]") -> None:
+        """Append BrokerMiddleware to the end of middlewares list.
+
+        Current middleware will be used as a most inner of already existed ones.
+        """
+        self._middlewares = (*self._middlewares, middleware)
+
+        for sub in self._subscribers.values():
+            sub.add_middleware(middleware)
+
+        for pub in self._publishers.values():
+            pub.add_middleware(middleware)
+
     @abstractmethod
     def subscriber(
         self,

--- a/faststream/broker/message.py
+++ b/faststream/broker/message.py
@@ -6,6 +6,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Generic,
+    List,
     Optional,
     Sequence,
     Tuple,
@@ -38,6 +39,7 @@ class StreamMessage(Generic[MsgType]):
 
     body: Union[bytes, Any]
     headers: "AnyDict" = field(default_factory=dict)
+    batch_headers: List["AnyDict"] = field(default_factory=list)
     path: "AnyDict" = field(default_factory=dict)
 
     content_type: Optional[str] = None

--- a/faststream/broker/publisher/proto.py
+++ b/faststream/broker/publisher/proto.py
@@ -57,8 +57,7 @@ class PublisherProto(
     _producer: Optional["ProducerProto"]
 
     @abstractmethod
-    def add_middleware(self, middleware: "BrokerMiddleware[MsgType]") -> None:
-        ...
+    def add_middleware(self, middleware: "BrokerMiddleware[MsgType]") -> None: ...
 
     @staticmethod
     @abstractmethod

--- a/faststream/broker/publisher/proto.py
+++ b/faststream/broker/publisher/proto.py
@@ -56,6 +56,10 @@ class PublisherProto(
     _middlewares: Iterable["PublisherMiddleware"]
     _producer: Optional["ProducerProto"]
 
+    @abstractmethod
+    def add_middleware(self, middleware: "BrokerMiddleware[MsgType]") -> None:
+        ...
+
     @staticmethod
     @abstractmethod
     def create() -> "PublisherProto[MsgType]":

--- a/faststream/broker/publisher/usecase.py
+++ b/faststream/broker/publisher/usecase.py
@@ -19,7 +19,12 @@ from faststream.asyncapi.abc import AsyncAPIOperation
 from faststream.asyncapi.message import get_response_schema
 from faststream.asyncapi.utils import to_camelcase
 from faststream.broker.publisher.proto import PublisherProto
-from faststream.broker.types import MsgType, P_HandlerParams, T_HandlerReturn
+from faststream.broker.types import (
+    BrokerMiddleware,
+    MsgType,
+    P_HandlerParams,
+    T_HandlerReturn,
+)
 from faststream.broker.wrapper.call import HandlerCallWrapper
 
 if TYPE_CHECKING:
@@ -86,6 +91,9 @@ class PublisherUsecase(
         self.description_ = description_
         self.include_in_schema = include_in_schema
         self.schema_ = schema_
+
+    def add_middleware(self, middleware: "BrokerMiddleware[MsgType]") -> None:
+        self._broker_middlewares = (*self._broker_middlewares, middleware)
 
     @override
     def setup(  # type: ignore[override]

--- a/faststream/broker/subscriber/proto.py
+++ b/faststream/broker/subscriber/proto.py
@@ -35,6 +35,10 @@ class SubscriberProto(
     _broker_middlewares: Iterable["BrokerMiddleware[MsgType]"]
     _producer: Optional["ProducerProto"]
 
+    @abstractmethod
+    def add_middleware(self, middleware: "BrokerMiddleware[MsgType]") -> None:
+        ...
+
     @staticmethod
     @abstractmethod
     def create() -> "SubscriberProto[MsgType]":

--- a/faststream/broker/subscriber/proto.py
+++ b/faststream/broker/subscriber/proto.py
@@ -36,8 +36,7 @@ class SubscriberProto(
     _producer: Optional["ProducerProto"]
 
     @abstractmethod
-    def add_middleware(self, middleware: "BrokerMiddleware[MsgType]") -> None:
-        ...
+    def add_middleware(self, middleware: "BrokerMiddleware[MsgType]") -> None: ...
 
     @staticmethod
     @abstractmethod

--- a/faststream/broker/subscriber/usecase.py
+++ b/faststream/broker/subscriber/usecase.py
@@ -131,6 +131,9 @@ class SubscriberUsecase(
         self.description_ = description_
         self.include_in_schema = include_in_schema
 
+    def add_middleware(self, middleware: "BrokerMiddleware[MsgType]") -> None:
+        self._broker_middlewares = (*self._broker_middlewares, middleware)
+
     @override
     def setup(  # type: ignore[override]
         self,

--- a/faststream/cli/docs/app.py
+++ b/faststream/cli/docs/app.py
@@ -108,7 +108,9 @@ def gen(
         ),
     ),
     is_factory: bool = typer.Option(
-        False, "--factory", help="Treat APP as an application factory"
+        False,
+        "--factory",
+        help="Treat APP as an application factory",
     ),
 ) -> None:
     """Generate project AsyncAPI schema."""

--- a/faststream/cli/docs/app.py
+++ b/faststream/cli/docs/app.py
@@ -45,8 +45,7 @@ def serve(
         ),
     ),
     is_factory: bool = typer.Option(
-        False,
-        "--factory", help="Treat APP as an application factory"
+        False, "--factory", help="Treat APP as an application factory"
     ),
 ) -> None:
     """Serve project AsyncAPI schema."""
@@ -109,8 +108,7 @@ def gen(
         ),
     ),
     is_factory: bool = typer.Option(
-        False,
-        "--factory", help="Treat APP as an application factory"
+        False, "--factory", help="Treat APP as an application factory"
     ),
 ) -> None:
     """Generate project AsyncAPI schema."""

--- a/faststream/cli/main.py
+++ b/faststream/cli/main.py
@@ -210,8 +210,7 @@ def publish(
     message: str = typer.Argument(..., help="Message to be published"),
     rpc: bool = typer.Option(False, help="Enable RPC mode and system output"),
     is_factory: bool = typer.Option(
-        False,
-        "--factory", help="Treat APP as an application factory"
+        False, "--factory", help="Treat APP as an application factory"
     ),
 ) -> None:
     """Publish a message using the specified broker in a FastStream application.

--- a/faststream/cli/main.py
+++ b/faststream/cli/main.py
@@ -210,7 +210,10 @@ def publish(
     message: str = typer.Argument(..., help="Message to be published"),
     rpc: bool = typer.Option(False, help="Enable RPC mode and system output"),
     is_factory: bool = typer.Option(
-        False, "--factory", help="Treat APP as an application factory"
+        False,
+        "--factory",
+        is_flag=True,
+        help="Treat APP as an application factory",
     ),
 ) -> None:
     """Publish a message using the specified broker in a FastStream application.

--- a/faststream/confluent/parser.py
+++ b/faststream/confluent/parser.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, Union
 
 from faststream.broker.message import decode_message, gen_cor_id
 from faststream.confluent.message import FAKE_CONSUMER, KafkaMessage
@@ -20,18 +20,14 @@ class AsyncConfluentParser:
         message: "Message",
     ) -> "StreamMessage[Message]":
         """Parses a Kafka message."""
-        headers = {}
-        if message.headers() is not None:
-            for i, j in message.headers():  # type: ignore[union-attr]
-                if isinstance(j, str):
-                    headers[i] = j
-                else:
-                    headers[i] = j.decode()
+        headers = _parse_msg_headers(message.headers())
+
         body = message.value()
         offset = message.offset()
         _, timestamp = message.timestamp()
 
         handler: Optional["LogicSubscriber[Any]"] = context.get_local("handler_")
+
         return KafkaMessage(
             body=body,
             headers=headers,
@@ -49,28 +45,29 @@ class AsyncConfluentParser:
         message: Tuple["Message", ...],
     ) -> "StreamMessage[Tuple[Message, ...]]":
         """Parses a batch of messages from a Kafka consumer."""
+        body: List[Any] = []
+        batch_headers: List[Dict[str, str]] = []
+
         first = message[0]
         last = message[-1]
 
-        headers = {}
-        if first.headers() is not None:
-            for i, j in first.headers():  # type: ignore[union-attr]
-                if isinstance(j, str):
-                    headers[i] = j
-                else:
-                    headers[i] = j.decode()
-        body = [m.value() for m in message]
-        first_offset = first.offset()
-        last_offset = last.offset()
+        for m in message:
+            body.append(m.value)
+            batch_headers.append(_parse_msg_headers(m.headers()))
+
+        headers = next(iter(batch_headers), {})
+
         _, first_timestamp = first.timestamp()
 
         handler: Optional["LogicSubscriber[Any]"] = context.get_local("handler_")
+
         return KafkaMessage(
             body=body,
             headers=headers,
+            batch_headers=batch_headers,
             reply_to=headers.get("reply_to", ""),
             content_type=headers.get("content-type"),
-            message_id=f"{first_offset}-{last_offset}-{first_timestamp}",
+            message_id=f"{first.offset()}-{last.offset()}-{first_timestamp}",
             correlation_id=headers.get("correlation_id", gen_cor_id()),
             raw_message=message,
             consumer=getattr(handler, "consumer", None) or FAKE_CONSUMER,
@@ -91,3 +88,9 @@ class AsyncConfluentParser:
     ) -> "DecodedMessage":
         """Decode a batch of messages."""
         return [decode_message(await cls.parse_message(m)) for m in msg.raw_message]
+
+
+def _parse_msg_headers(
+    headers: Sequence[Tuple[str, Union[bytes, str]]],
+) -> Dict[str, str]:
+    return {i: j if isinstance(j, str) else j.decode() for i, j in headers}

--- a/faststream/nats/broker/broker.py
+++ b/faststream/nats/broker/broker.py
@@ -623,12 +623,12 @@ class NatsBroker(
                     )
 
                 except BadRequestError as e:
-                    old_config = (await self.stream.stream_info(stream.name)).config
-
                     if (
                         e.description
                         == "stream name already in use with a different configuration"
                     ):
+                        old_config = (await self.stream.stream_info(stream.name)).config
+
                         self._log(str(e), logging.WARNING, log_context)
                         await self.stream.update_stream(
                             config=stream.config,

--- a/faststream/nats/parser.py
+++ b/faststream/nats/parser.py
@@ -104,13 +104,17 @@ class BatchParser(JsParser):
     ) -> "StreamMessage[List[Msg]]":
         if first_msg := next(iter(message), None):
             path = self.get_path(first_msg.subject)
+            headers = first_msg.headers
+
         else:
             path = None
+            headers = None
 
         return NatsBatchMessage(
             raw_message=message,
             body=[m.data for m in message],
             path=path or {},
+            headers=headers or {},
         )
 
     async def decode_batch(

--- a/faststream/nats/parser.py
+++ b/faststream/nats/parser.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 from faststream.broker.message import StreamMessage, decode_message, gen_cor_id
 from faststream.nats.message import NatsBatchMessage, NatsMessage
@@ -102,19 +102,27 @@ class BatchParser(JsParser):
         self,
         message: List["Msg"],
     ) -> "StreamMessage[List[Msg]]":
-        if first_msg := next(iter(message), None):
-            path = self.get_path(first_msg.subject)
-            headers = first_msg.headers
+        body: List[bytes] = []
+        batch_headers: List[Dict[str, str]] = []
+
+        if message:
+            path = self.get_path(message[0].subject)
+
+            for m in message:
+                batch_headers.append(m.headers or {})
+                body.append(m.data)
 
         else:
             path = None
-            headers = None
+
+        headers = next(iter(batch_headers), {})
 
         return NatsBatchMessage(
             raw_message=message,
-            body=[m.data for m in message],
+            body=body,
             path=path or {},
-            headers=headers or {},
+            headers=headers,
+            batch_headers=batch_headers,
         )
 
     async def decode_batch(

--- a/faststream/rabbit/__init__.py
+++ b/faststream/rabbit/__init__.py
@@ -21,5 +21,6 @@ __all__ = (
     "ReplyConfig",
     "RabbitExchange",
     "RabbitQueue",
+    # Annotations
     "RabbitMessage",
 )

--- a/faststream/rabbit/annotations.py
+++ b/faststream/rabbit/annotations.py
@@ -1,3 +1,4 @@
+from aio_pika import RobustChannel, RobustConnection
 from typing_extensions import Annotated
 
 from faststream.annotations import ContextRepo, Logger, NoCast
@@ -13,8 +14,20 @@ __all__ = (
     "RabbitMessage",
     "RabbitBroker",
     "RabbitProducer",
+    "Channel",
+    "Connection",
 )
 
 RabbitMessage = Annotated[RM, Context("message")]
 RabbitBroker = Annotated[RB, Context("broker")]
 RabbitProducer = Annotated[AioPikaFastProducer, Context("broker._producer")]
+
+Channel = Annotated[RobustChannel, Context("broker._channel")]
+Connection = Annotated[RobustConnection, Context("broker._connection")]
+
+# NOTE: transaction is not for the public usage yet
+# async def _get_transaction(connection: Connection) -> RabbitTransaction:
+#     async with connection.channel(publisher_confirms=False) as channel:
+#         yield channel.transaction()
+
+# Transaction = Annotated[RabbitTransaction, Depends(_get_transaction)]

--- a/faststream/rabbit/broker/broker.py
+++ b/faststream/rabbit/broker/broker.py
@@ -118,7 +118,7 @@ class RabbitBroker(
             Doc(
                 "raise an :class:`aio_pika.exceptions.DeliveryError`"
                 "when mandatory message will be returned"
-            )
+            ),
         ] = False,
         # broker args
         max_consumers: Annotated[
@@ -345,7 +345,7 @@ class RabbitBroker(
             Doc(
                 "raise an :class:`aio_pika.exceptions.DeliveryError`"
                 "when mandatory message will be returned"
-            )
+            ),
         ] = Parameter.empty,
     ) -> "RobustConnection":
         """Connect broker object to RabbitMQ.

--- a/faststream/rabbit/fastapi/router.py
+++ b/faststream/rabbit/fastapi/router.py
@@ -114,7 +114,7 @@ class RabbitRouter(StreamRouter["IncomingMessage"]):
             Doc(
                 "raise an :class:`aio_pika.exceptions.DeliveryError`"
                 "when mandatory message will be returned"
-            )
+            ),
         ] = False,
         # broker args
         max_consumers: Annotated[

--- a/faststream/rabbit/fastapi/router.py
+++ b/faststream/rabbit/fastapi/router.py
@@ -96,6 +96,26 @@ class RabbitRouter(StreamRouter["IncomingMessage"]):
             "TimeoutType",
             Doc("Connection establishement timeout."),
         ] = None,
+        # channel args
+        channel_number: Annotated[
+            Optional[int],
+            Doc("Specify the channel number explicit."),
+        ] = None,
+        publisher_confirms: Annotated[
+            bool,
+            Doc(
+                "if `True` the `publish` method will "
+                "return `bool` type after publish is complete."
+                "Otherwise it will returns `None`."
+            ),
+        ] = True,
+        on_return_raises: Annotated[
+            bool,
+            Doc(
+                "raise an :class:`aio_pika.exceptions.DeliveryError`"
+                "when mandatory message will be returned"
+            )
+        ] = False,
         # broker args
         max_consumers: Annotated[
             Optional[int],
@@ -408,6 +428,9 @@ class RabbitRouter(StreamRouter["IncomingMessage"]):
             graceful_timeout=graceful_timeout,
             decoder=decoder,
             parser=parser,
+            channel_number=channel_number,
+            publisher_confirms=publisher_confirms,
+            on_return_raises=on_return_raises,
             middlewares=middlewares,
             security=security,
             asyncapi_url=asyncapi_url,

--- a/faststream/rabbit/schemas/queue.py
+++ b/faststream/rabbit/schemas/queue.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import TYPE_CHECKING, Optional
 
 from typing_extensions import Annotated, Doc
@@ -115,3 +116,13 @@ class RabbitQueue(NameRequired):
         self.auto_delete = auto_delete
         self.arguments = arguments
         self.timeout = timeout
+
+    def add_prefix(self, prefix: str) -> "RabbitQueue":
+        new_q: RabbitQueue = deepcopy(self)
+
+        new_q.name = "".join((prefix, new_q.name))
+
+        if new_q.routing_key:
+            new_q.routing_key = "".join((prefix, new_q.routing_key))
+
+        return new_q

--- a/faststream/rabbit/subscriber/usecase.py
+++ b/faststream/rabbit/subscriber/usecase.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -223,6 +222,4 @@ class LogicSubscriber(
 
     def add_prefix(self, prefix: str) -> None:
         """Include Subscriber in router."""
-        new_q = deepcopy(self.queue)
-        new_q.name = "".join((prefix, new_q.name))
-        self.queue = new_q
+        self.queue = self.queue.add_prefix(prefix)

--- a/faststream/redis/parser.py
+++ b/faststream/redis/parser.py
@@ -1,7 +1,7 @@
 from typing import (
     TYPE_CHECKING,
     Any,
-    Dict,
+    List,
     Mapping,
     Optional,
     Sequence,
@@ -136,13 +136,16 @@ class SimpleParser:
         self,
         message: Mapping[str, Any],
     ) -> "StreamMessage[Mapping[str, Any]]":
-        data, headers = self._parse_data(message)
+        data, headers, batch_headers = self._parse_data(message)
+
         id_ = gen_cor_id()
+
         return self.msg_class(
             raw_message=message,
             body=data,
             path=self.get_path(message),
             headers=headers,
+            batch_headers=batch_headers,
             reply_to=headers.get("reply_to", ""),
             content_type=headers.get("content-type"),
             message_id=headers.get("message_id", id_),
@@ -150,8 +153,10 @@ class SimpleParser:
         )
 
     @staticmethod
-    def _parse_data(message: Mapping[str, Any]) -> Tuple[bytes, "AnyDict"]:
-        return RawMessage.parse(message["data"])
+    def _parse_data(
+        message: Mapping[str, Any],
+    ) -> Tuple[bytes, "AnyDict", List["AnyDict"]]:
+        return (*RawMessage.parse(message["data"]), [])
 
     def get_path(self, message: Mapping[str, Any]) -> "AnyDict":
         if (
@@ -183,14 +188,26 @@ class RedisBatchListParser(SimpleParser):
     msg_class = RedisBatchListMessage
 
     @staticmethod
-    def _parse_data(message: Mapping[str, Any]) -> Tuple[bytes, "AnyDict"]:
-        data = [_decode_batch_body_item(x) for x in message["data"]]
+    def _parse_data(
+        message: Mapping[str, Any],
+    ) -> Tuple[bytes, "AnyDict", List["AnyDict"]]:
+        body: List[Any] = []
+        batch_headers: List["AnyDict"] = []
+
+        for x in message["data"]:
+            msg_data, msg_headers = _decode_batch_body_item(x)
+            body.append(msg_data)
+            batch_headers.append(msg_headers)
+
+        first_msg_headers = next(iter(batch_headers), {})
+
         return (
-            dump_json(i[0] for i in data),
+            dump_json(body),
             {
-                **data[0][1],
-                "content-type": ContentTypes.json,
+                **first_msg_headers,
+                "content-type": ContentTypes.json.value,
             },
+            batch_headers,
         )
 
 
@@ -198,27 +215,41 @@ class RedisStreamParser(SimpleParser):
     msg_class = RedisStreamMessage
 
     @classmethod
-    def _parse_data(cls, message: Mapping[str, Any]) -> Tuple[bytes, "AnyDict"]:
+    def _parse_data(
+        cls, message: Mapping[str, Any]
+    ) -> Tuple[bytes, "AnyDict", List["AnyDict"]]:
         data = message["data"]
-        return RawMessage.parse(data.get(bDATA_KEY) or dump_json(data))
+        return (*RawMessage.parse(data.get(bDATA_KEY) or dump_json(data)), [])
 
 
 class RedisBatchStreamParser(SimpleParser):
     msg_class = RedisBatchStreamMessage
 
     @staticmethod
-    def _parse_data(message: Mapping[str, Any]) -> Tuple[bytes, "AnyDict"]:
-        data = [_decode_batch_body_item(x.get(bDATA_KEY, x)) for x in message["data"]]
+    def _parse_data(
+        message: Mapping[str, Any],
+    ) -> Tuple[bytes, "AnyDict", List["AnyDict"]]:
+        body: List[Any] = []
+        batch_headers: List["AnyDict"] = []
+
+        for x in message["data"]:
+            msg_data, msg_headers = _decode_batch_body_item(x.get(bDATA_KEY, x))
+            body.append(msg_data)
+            batch_headers.append(msg_headers)
+
+        first_msg_headers = next(iter(batch_headers), {})
+
         return (
-            dump_json(i[0] for i in data),
+            dump_json(body),
             {
-                **data[0][1],
-                "content-type": ContentTypes.json,
+                **first_msg_headers,
+                "content-type": ContentTypes.json.value,
             },
+            batch_headers,
         )
 
 
-def _decode_batch_body_item(msg_content: bytes) -> Tuple[Any, Dict[str, str]]:
+def _decode_batch_body_item(msg_content: bytes) -> Tuple[Any, "AnyDict"]:
     msg_body, headers = RawMessage.parse(msg_content)
     try:
         return json_loads(msg_body), headers

--- a/faststream/types.py
+++ b/faststream/types.py
@@ -63,22 +63,16 @@ class StandardDataclass(Protocol):
     """Protocol to check type is dataclass."""
 
     __dataclass_fields__: ClassVar[Dict[str, Any]]
-    __dataclass_params__: ClassVar[Any]
-    __post_init__: ClassVar[Callable[..., None]]
-
-    def __init__(self, *args: object, **kwargs: object) -> None:
-        """Interface method."""
-        ...
 
 
 BaseSendableMessage: TypeAlias = Union[
     JsonDecodable,
     Decimal,
     datetime,
-    None,
     StandardDataclass,
     SendableTable,
     SendableArray,
+    None,
 ]
 
 try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,9 +76,9 @@ redis = ["redis>=5.0.0,<6.0.0"]
 # dev dependencies
 devdocs = [
     "mkdocs-material==9.5.21",
-    "mkdocs-static-i18n==1.2.2",
+    "mkdocs-static-i18n==1.2.3",
     "mdx-include==1.4.2",
-    "mkdocstrings[python]==0.25.0",
+    "mkdocstrings[python]==0.25.1",
     "mkdocs-literate-nav==0.6.1",
     "mkdocs-git-revision-date-localized-plugin==1.2.5",
     "mike==2.1.1",                                      # versioning
@@ -106,14 +106,14 @@ types = [
 
 lint = [
     "faststream[types]",
-    "ruff==0.4.3",
+    "ruff==0.4.4",
     "bandit==1.7.8",
     "semgrep==1.70.0",
     "codespell==2.2.6",
 ]
 
 test-core = [
-    "coverage[toml]==7.4.4",
+    "coverage[toml]==7.5.1",
     "pytest==8.2.0",
     "pytest-asyncio==0.23.6",
     "dirty-equals==0.7.1.post0",
@@ -133,7 +133,7 @@ dev = [
     "faststream[rabbit,kafka,confluent,nats,redis,lint,testing,devdocs]",
     "pre-commit==3.5.0; python_version < '3.9'",
     "pre-commit==3.7.0; python_version >= '3.9'",
-    "detect-secrets==1.4.0",
+    "detect-secrets==1.5.0",
 ]
 
 [project.urls]

--- a/tests/asyncapi/rabbit/test_router.py
+++ b/tests/asyncapi/rabbit/test_router.py
@@ -63,7 +63,7 @@ class TestRouter(RouterTestcase):
                         "subscribe": {
                             "bindings": {
                                 "amqp": {
-                                    "cc": "key",
+                                    "cc": "test_key",
                                     "ack": True,
                                     "bindingVersion": "0.2.0",
                                 }
@@ -91,7 +91,7 @@ class TestRouter(RouterTestcase):
                     },
                 },
             }
-        )
+        ), schema
 
 
 class TestRouterArguments(ArgumentsTestcase):

--- a/tests/brokers/base/middlewares.py
+++ b/tests/brokers/base/middlewares.py
@@ -271,7 +271,11 @@ class MiddlewareTestcase(LocalMiddlewareTestcase):
         mock.end.assert_called_once()
 
     async def test_add_global_middleware(
-        self, event: asyncio.Event, queue: str, mock: Mock, raw_broker,
+        self,
+        event: asyncio.Event,
+        queue: str,
+        mock: Mock,
+        raw_broker,
     ):
         class mid(BaseMiddleware):  # noqa: N801
             async def on_receive(self):

--- a/tests/brokers/base/publish.py
+++ b/tests/brokers/base/publish.py
@@ -1,4 +1,5 @@
 import asyncio
+from dataclasses import asdict, dataclass
 from datetime import datetime
 from typing import Any, ClassVar, Dict, List, Tuple
 from unittest.mock import Mock
@@ -7,12 +8,17 @@ import anyio
 import pytest
 from pydantic import BaseModel
 
-from faststream._compat import model_to_json
+from faststream._compat import dump_json, model_to_json
 from faststream.annotations import Logger
 from faststream.broker.core.usecase import BrokerUsecase
 
 
 class SimpleModel(BaseModel):
+    r: str
+
+
+@dataclass
+class SimpleDataclass:
     r: str
 
 
@@ -54,6 +60,12 @@ class BrokerPublishTestcase:
                 float,
                 1.0,
                 id="float->float",
+            ),
+            pytest.param(
+                1,
+                float,
+                1.0,
+                id="int->float",
             ),
             pytest.param(
                 False,
@@ -102,6 +114,30 @@ class BrokerPublishTestcase:
                 SimpleModel,
                 SimpleModel(r="hello!"),
                 id="dict->model",
+            ),
+            pytest.param(
+                dump_json(asdict(SimpleDataclass(r="hello!"))),
+                SimpleDataclass,
+                SimpleDataclass(r="hello!"),
+                id="bytes->dataclass",
+            ),
+            pytest.param(
+                SimpleDataclass(r="hello!"),
+                SimpleDataclass,
+                SimpleDataclass(r="hello!"),
+                id="dataclass->dataclass",
+            ),
+            pytest.param(
+                SimpleDataclass(r="hello!"),
+                dict,
+                {"r": "hello!"},
+                id="dataclass->dict",
+            ),
+            pytest.param(
+                {"r": "hello!"},
+                SimpleDataclass,
+                SimpleDataclass(r="hello!"),
+                id="dict->dataclass",
             ),
         ),
     )

--- a/tests/brokers/kafka/test_consume.py
+++ b/tests/brokers/kafka/test_consume.py
@@ -34,6 +34,38 @@ class TestConsume(BrokerRealConsumeTestcase):
         assert [{1, "hi"}] == [set(r.result()) for r in result]
 
     @pytest.mark.asyncio()
+    async def test_consume_batch_headers(
+        self, mock, event: asyncio.Event, queue: str, full_broker: KafkaBroker
+    ):
+        @full_broker.subscriber(queue, batch=True)
+        def subscriber(m, msg: KafkaMessage):
+            check = all(
+                (
+                    msg.headers,
+                    [msg.headers] == msg.batch_headers,
+                    msg.headers.get("custom") == "1",
+                )
+            )
+            mock(check)
+            event.set()
+
+        async with full_broker:
+            await full_broker.start()
+
+            await asyncio.wait(
+                (
+                    asyncio.create_task(
+                        full_broker.publish("", queue, headers={"custom": "1"})
+                    ),
+                    asyncio.create_task(event.wait()),
+                ),
+                timeout=3,
+            )
+
+        assert event.is_set()
+        mock.assert_called_once_with(True)
+
+    @pytest.mark.asyncio()
     @pytest.mark.slow()
     async def test_consume_ack(
         self,

--- a/tests/brokers/redis/test_fastapi.py
+++ b/tests/brokers/redis/test_fastapi.py
@@ -86,7 +86,7 @@ class TestRouter(FastAPITestcase):
     ):
         router = RedisRouter()
 
-        @router.subscriber(stream=StreamSub(queue, polling_interval=3000))
+        @router.subscriber(stream=StreamSub(queue, polling_interval=10))
         async def handler(msg):
             mock(msg)
             event.set()
@@ -114,7 +114,7 @@ class TestRouter(FastAPITestcase):
     ):
         router = RedisRouter()
 
-        @router.subscriber(stream=StreamSub(queue, polling_interval=3000, batch=True))
+        @router.subscriber(stream=StreamSub(queue, polling_interval=10, batch=True))
         async def handler(msg: List[str]):
             mock(msg)
             event.set()


### PR DESCRIPTION
# Description

1. Feature: Add `from faststream.rabbit.annotations import Connection, Channel` shortcuts

2. Bugfix: RabbitMQ RabbitRouter prefix now affects to queue routing key as well

3. Feature (close #1402): add `broker.add_middleware` public API to append a middleware to already created broker

4. Feature: add `RabbitBroker(channel_number: int, publisher_confirms: bool, on_return_raises: bool)` options to setup channel settings

5. Featur (close #1447): add `StreamMessage.batch_headers` attribute to provide with access to whole batch messages headers

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [x] Bug fix (a non-breaking change that resolves an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-anaylysis.sh`
- [ ] I have included code examples to illustrate the modifications
