### PR TITLE
fix: add group/consumer to hash to avoid overwriting

### DIFF
--- a/faststream/redis/schemas/stream_sub.py
+++ b/faststream/redis/schemas/stream_sub.py
@@ -57,4 +57,8 @@ class StreamSub(NameRequired):
         self.max_records = max_records
 
     def __hash__(self) -> int:
+        if self.group is not None:
+            return hash(
+                f"stream:{self.name} group:{self.group} consumer:{self.consumer}"
+            )
         return hash(f"stream:{self.name}")


### PR DESCRIPTION
# Description

This allows subscribers to use the same Redis stream:

+ with the same group, but with multiple consumers to load balance the messages between several subscribers.

````python
@broker.subscriber(stream="test-stream", group="test-group-1", consumer="test-consumer-1")
async def handle_1(msg: str):
    print(msg)

@broker.subscriber(stream="test-stream", group="test-group-1", consumer="test-consumer-2")
async def handle_2(msg: str):
    print(msg)
````

+ with multiple groups to allow a message to be handled by multiple subscribers (pub/sub)

````python
@broker.subscriber(stream="test-stream", group="test-group-1", consumer="test-consumer-1")
async def sub_1(msg: str):
    print(msg)

@broker.subscriber(stream="test-stream", group="test-group-2", consumer="test-consumer-2")
async def sub_2(msg: str):
    print(msg)
````

Without this fix, the subscribers are overwritten because the group and consumer are not part of the hash.

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [X] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [X] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [X] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [X] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [X] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [X] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
