### PR TITLE
Remove typing-extensions version restriction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
     "anyio>=3.7.1,<5",
     "fast-depends>=2.4.0b0,<2.5.0",
     "typer>=0.9,!=0.12,<1",
-    "typing-extensions>=4.8.0,!=4.12.*",
+    "typing-extensions>=4.8.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
# Description

Undo the version restriction of `typing-extensions` package introduced here - https://github.com/airtai/faststream/pull/1467

Fixes # (issue number)

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [ ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
