### PR TITLE
feat (#1431): add Response class

### DIFF
--- a/docs/docs/SUMMARY.md
+++ b/docs/docs/SUMMARY.md
@@ -116,21 +116,16 @@ search:
             - [FastStream](public_api/faststream/FastStream.md)
             - [Header](public_api/faststream/Header.md)
             - [Path](public_api/faststream/Path.md)
+            - [Response](public_api/faststream/Response.md)
             - [TestApp](public_api/faststream/TestApp.md)
             - [apply_types](public_api/faststream/apply_types.md)
             - asyncapi
                 - [get_app_schema](public_api/faststream/asyncapi/get_app_schema.md)
                 - [get_asyncapi_html](public_api/faststream/asyncapi/get_asyncapi_html.md)
-            - confluent
-                - [KafkaBroker](public_api/faststream/confluent/KafkaBroker.md)
-                - [KafkaPublisher](public_api/faststream/confluent/KafkaPublisher.md)
-                - [KafkaRoute](public_api/faststream/confluent/KafkaRoute.md)
-                - [KafkaRouter](public_api/faststream/confluent/KafkaRouter.md)
-                - [TestApp](public_api/faststream/confluent/TestApp.md)
-                - [TestKafkaBroker](public_api/faststream/confluent/TestKafkaBroker.md)
             - kafka
                 - [KafkaBroker](public_api/faststream/kafka/KafkaBroker.md)
                 - [KafkaPublisher](public_api/faststream/kafka/KafkaPublisher.md)
+                - [KafkaResponse](public_api/faststream/kafka/KafkaResponse.md)
                 - [KafkaRoute](public_api/faststream/kafka/KafkaRoute.md)
                 - [KafkaRouter](public_api/faststream/kafka/KafkaRouter.md)
                 - [TestApp](public_api/faststream/kafka/TestApp.md)
@@ -146,6 +141,7 @@ search:
                 - [KvWatch](public_api/faststream/nats/KvWatch.md)
                 - [NatsBroker](public_api/faststream/nats/NatsBroker.md)
                 - [NatsPublisher](public_api/faststream/nats/NatsPublisher.md)
+                - [NatsResponse](public_api/faststream/nats/NatsResponse.md)
                 - [NatsRoute](public_api/faststream/nats/NatsRoute.md)
                 - [NatsRouter](public_api/faststream/nats/NatsRouter.md)
                 - [ObjWatch](public_api/faststream/nats/ObjWatch.md)
@@ -165,6 +161,7 @@ search:
                 - [RabbitExchange](public_api/faststream/rabbit/RabbitExchange.md)
                 - [RabbitPublisher](public_api/faststream/rabbit/RabbitPublisher.md)
                 - [RabbitQueue](public_api/faststream/rabbit/RabbitQueue.md)
+                - [RabbitResponse](public_api/faststream/rabbit/RabbitResponse.md)
                 - [RabbitRoute](public_api/faststream/rabbit/RabbitRoute.md)
                 - [RabbitRouter](public_api/faststream/rabbit/RabbitRouter.md)
                 - [ReplyConfig](public_api/faststream/rabbit/ReplyConfig.md)
@@ -175,6 +172,7 @@ search:
                 - [PubSub](public_api/faststream/redis/PubSub.md)
                 - [RedisBroker](public_api/faststream/redis/RedisBroker.md)
                 - [RedisPublisher](public_api/faststream/redis/RedisPublisher.md)
+                - [RedisResponse](public_api/faststream/redis/RedisResponse.md)
                 - [RedisRoute](public_api/faststream/redis/RedisRoute.md)
                 - [RedisRouter](public_api/faststream/redis/RedisRouter.md)
                 - [StreamSub](public_api/faststream/redis/StreamSub.md)
@@ -188,6 +186,7 @@ search:
             - [FastStream](api/faststream/FastStream.md)
             - [Header](api/faststream/Header.md)
             - [Path](api/faststream/Path.md)
+            - [Response](api/faststream/Response.md)
             - [TestApp](api/faststream/TestApp.md)
             - [apply_types](api/faststream/apply_types.md)
             - app
@@ -349,6 +348,8 @@ search:
                         - [PublisherProto](api/faststream/broker/publisher/proto/PublisherProto.md)
                     - usecase
                         - [PublisherUsecase](api/faststream/broker/publisher/usecase/PublisherUsecase.md)
+                - response
+                    - [Response](api/faststream/broker/response/Response.md)
                 - router
                     - [ArgsContainer](api/faststream/broker/router/ArgsContainer.md)
                     - [BrokerRouter](api/faststream/broker/router/BrokerRouter.md)
@@ -410,85 +411,6 @@ search:
                     - parser
                         - [parse_cli_args](api/faststream/cli/utils/parser/parse_cli_args.md)
                         - [remove_prefix](api/faststream/cli/utils/parser/remove_prefix.md)
-            - confluent
-                - [KafkaBroker](api/faststream/confluent/KafkaBroker.md)
-                - [KafkaPublisher](api/faststream/confluent/KafkaPublisher.md)
-                - [KafkaRoute](api/faststream/confluent/KafkaRoute.md)
-                - [KafkaRouter](api/faststream/confluent/KafkaRouter.md)
-                - [TestApp](api/faststream/confluent/TestApp.md)
-                - [TestKafkaBroker](api/faststream/confluent/TestKafkaBroker.md)
-                - broker
-                    - [KafkaBroker](api/faststream/confluent/broker/KafkaBroker.md)
-                    - broker
-                        - [KafkaBroker](api/faststream/confluent/broker/broker/KafkaBroker.md)
-                    - logging
-                        - [KafkaLoggingBroker](api/faststream/confluent/broker/logging/KafkaLoggingBroker.md)
-                    - registrator
-                        - [KafkaRegistrator](api/faststream/confluent/broker/registrator/KafkaRegistrator.md)
-                - client
-                    - [AsyncConfluentConsumer](api/faststream/confluent/client/AsyncConfluentConsumer.md)
-                    - [AsyncConfluentProducer](api/faststream/confluent/client/AsyncConfluentProducer.md)
-                    - [BatchBuilder](api/faststream/confluent/client/BatchBuilder.md)
-                    - [MsgToSend](api/faststream/confluent/client/MsgToSend.md)
-                    - [TopicPartition](api/faststream/confluent/client/TopicPartition.md)
-                    - [check_msg_error](api/faststream/confluent/client/check_msg_error.md)
-                    - [create_topics](api/faststream/confluent/client/create_topics.md)
-                - fastapi
-                    - [Context](api/faststream/confluent/fastapi/Context.md)
-                    - [KafkaRouter](api/faststream/confluent/fastapi/KafkaRouter.md)
-                    - fastapi
-                        - [KafkaRouter](api/faststream/confluent/fastapi/fastapi/KafkaRouter.md)
-                - message
-                    - [ConsumerProtocol](api/faststream/confluent/message/ConsumerProtocol.md)
-                    - [FakeConsumer](api/faststream/confluent/message/FakeConsumer.md)
-                    - [KafkaMessage](api/faststream/confluent/message/KafkaMessage.md)
-                - opentelemetry
-                    - [KafkaTelemetryMiddleware](api/faststream/confluent/opentelemetry/KafkaTelemetryMiddleware.md)
-                    - middleware
-                        - [KafkaTelemetryMiddleware](api/faststream/confluent/opentelemetry/middleware/KafkaTelemetryMiddleware.md)
-                    - provider
-                        - [BaseConfluentTelemetrySettingsProvider](api/faststream/confluent/opentelemetry/provider/BaseConfluentTelemetrySettingsProvider.md)
-                        - [BatchConfluentTelemetrySettingsProvider](api/faststream/confluent/opentelemetry/provider/BatchConfluentTelemetrySettingsProvider.md)
-                        - [ConfluentTelemetrySettingsProvider](api/faststream/confluent/opentelemetry/provider/ConfluentTelemetrySettingsProvider.md)
-                        - [telemetry_attributes_provider_factory](api/faststream/confluent/opentelemetry/provider/telemetry_attributes_provider_factory.md)
-                - parser
-                    - [AsyncConfluentParser](api/faststream/confluent/parser/AsyncConfluentParser.md)
-                - publisher
-                    - asyncapi
-                        - [AsyncAPIBatchPublisher](api/faststream/confluent/publisher/asyncapi/AsyncAPIBatchPublisher.md)
-                        - [AsyncAPIDefaultPublisher](api/faststream/confluent/publisher/asyncapi/AsyncAPIDefaultPublisher.md)
-                        - [AsyncAPIPublisher](api/faststream/confluent/publisher/asyncapi/AsyncAPIPublisher.md)
-                    - producer
-                        - [AsyncConfluentFastProducer](api/faststream/confluent/publisher/producer/AsyncConfluentFastProducer.md)
-                    - usecase
-                        - [BatchPublisher](api/faststream/confluent/publisher/usecase/BatchPublisher.md)
-                        - [DefaultPublisher](api/faststream/confluent/publisher/usecase/DefaultPublisher.md)
-                        - [LogicPublisher](api/faststream/confluent/publisher/usecase/LogicPublisher.md)
-                - router
-                    - [KafkaPublisher](api/faststream/confluent/router/KafkaPublisher.md)
-                    - [KafkaRoute](api/faststream/confluent/router/KafkaRoute.md)
-                    - [KafkaRouter](api/faststream/confluent/router/KafkaRouter.md)
-                - schemas
-                    - params
-                        - [ConsumerConnectionParams](api/faststream/confluent/schemas/params/ConsumerConnectionParams.md)
-                - security
-                    - [parse_security](api/faststream/confluent/security/parse_security.md)
-                - subscriber
-                    - asyncapi
-                        - [AsyncAPIBatchSubscriber](api/faststream/confluent/subscriber/asyncapi/AsyncAPIBatchSubscriber.md)
-                        - [AsyncAPIDefaultSubscriber](api/faststream/confluent/subscriber/asyncapi/AsyncAPIDefaultSubscriber.md)
-                        - [AsyncAPISubscriber](api/faststream/confluent/subscriber/asyncapi/AsyncAPISubscriber.md)
-                    - factory
-                        - [create_subscriber](api/faststream/confluent/subscriber/factory/create_subscriber.md)
-                    - usecase
-                        - [BatchSubscriber](api/faststream/confluent/subscriber/usecase/BatchSubscriber.md)
-                        - [DefaultSubscriber](api/faststream/confluent/subscriber/usecase/DefaultSubscriber.md)
-                        - [LogicSubscriber](api/faststream/confluent/subscriber/usecase/LogicSubscriber.md)
-                - testing
-                    - [FakeProducer](api/faststream/confluent/testing/FakeProducer.md)
-                    - [MockConfluentMessage](api/faststream/confluent/testing/MockConfluentMessage.md)
-                    - [TestKafkaBroker](api/faststream/confluent/testing/TestKafkaBroker.md)
-                    - [build_message](api/faststream/confluent/testing/build_message.md)
             - constants
                 - [ContentTypes](api/faststream/constants/ContentTypes.md)
             - exceptions
@@ -506,6 +428,7 @@ search:
             - kafka
                 - [KafkaBroker](api/faststream/kafka/KafkaBroker.md)
                 - [KafkaPublisher](api/faststream/kafka/KafkaPublisher.md)
+                - [KafkaResponse](api/faststream/kafka/KafkaResponse.md)
                 - [KafkaRoute](api/faststream/kafka/KafkaRoute.md)
                 - [KafkaRouter](api/faststream/kafka/KafkaRouter.md)
                 - [TestApp](api/faststream/kafka/TestApp.md)
@@ -550,6 +473,8 @@ search:
                         - [BatchPublisher](api/faststream/kafka/publisher/usecase/BatchPublisher.md)
                         - [DefaultPublisher](api/faststream/kafka/publisher/usecase/DefaultPublisher.md)
                         - [LogicPublisher](api/faststream/kafka/publisher/usecase/LogicPublisher.md)
+                - response
+                    - [KafkaResponse](api/faststream/kafka/response/KafkaResponse.md)
                 - router
                     - [KafkaPublisher](api/faststream/kafka/router/KafkaPublisher.md)
                     - [KafkaRoute](api/faststream/kafka/router/KafkaRoute.md)
@@ -592,6 +517,7 @@ search:
                 - [KvWatch](api/faststream/nats/KvWatch.md)
                 - [NatsBroker](api/faststream/nats/NatsBroker.md)
                 - [NatsPublisher](api/faststream/nats/NatsPublisher.md)
+                - [NatsResponse](api/faststream/nats/NatsResponse.md)
                 - [NatsRoute](api/faststream/nats/NatsRoute.md)
                 - [NatsRouter](api/faststream/nats/NatsRouter.md)
                 - [ObjWatch](api/faststream/nats/ObjWatch.md)
@@ -657,6 +583,8 @@ search:
                         - [NatsJSFastProducer](api/faststream/nats/publisher/producer/NatsJSFastProducer.md)
                     - usecase
                         - [LogicPublisher](api/faststream/nats/publisher/usecase/LogicPublisher.md)
+                - response
+                    - [NatsResponse](api/faststream/nats/response/NatsResponse.md)
                 - router
                     - [NatsPublisher](api/faststream/nats/router/NatsPublisher.md)
                     - [NatsRoute](api/faststream/nats/router/NatsRoute.md)
@@ -728,6 +656,7 @@ search:
                 - [RabbitExchange](api/faststream/rabbit/RabbitExchange.md)
                 - [RabbitPublisher](api/faststream/rabbit/RabbitPublisher.md)
                 - [RabbitQueue](api/faststream/rabbit/RabbitQueue.md)
+                - [RabbitResponse](api/faststream/rabbit/RabbitResponse.md)
                 - [RabbitRoute](api/faststream/rabbit/RabbitRoute.md)
                 - [RabbitRouter](api/faststream/rabbit/RabbitRouter.md)
                 - [ReplyConfig](api/faststream/rabbit/ReplyConfig.md)
@@ -764,6 +693,8 @@ search:
                     - usecase
                         - [LogicPublisher](api/faststream/rabbit/publisher/usecase/LogicPublisher.md)
                         - [PublishKwargs](api/faststream/rabbit/publisher/usecase/PublishKwargs.md)
+                - response
+                    - [RabbitResponse](api/faststream/rabbit/response/RabbitResponse.md)
                 - router
                     - [RabbitPublisher](api/faststream/rabbit/router/RabbitPublisher.md)
                     - [RabbitRoute](api/faststream/rabbit/router/RabbitRoute.md)
@@ -808,6 +739,7 @@ search:
                 - [PubSub](api/faststream/redis/PubSub.md)
                 - [RedisBroker](api/faststream/redis/RedisBroker.md)
                 - [RedisPublisher](api/faststream/redis/RedisPublisher.md)
+                - [RedisResponse](api/faststream/redis/RedisResponse.md)
                 - [RedisRoute](api/faststream/redis/RedisRoute.md)
                 - [RedisRouter](api/faststream/redis/RedisRouter.md)
                 - [StreamSub](api/faststream/redis/StreamSub.md)
@@ -869,6 +801,8 @@ search:
                         - [ListPublisher](api/faststream/redis/publisher/usecase/ListPublisher.md)
                         - [LogicPublisher](api/faststream/redis/publisher/usecase/LogicPublisher.md)
                         - [StreamPublisher](api/faststream/redis/publisher/usecase/StreamPublisher.md)
+                - response
+                    - [RedisResponse](api/faststream/redis/response/RedisResponse.md)
                 - router
                     - [RedisPublisher](api/faststream/redis/router/RedisPublisher.md)
                     - [RedisRoute](api/faststream/redis/router/RedisRoute.md)

--- a/docs/docs/SUMMARY.md
+++ b/docs/docs/SUMMARY.md
@@ -122,6 +122,14 @@ search:
             - asyncapi
                 - [get_app_schema](public_api/faststream/asyncapi/get_app_schema.md)
                 - [get_asyncapi_html](public_api/faststream/asyncapi/get_asyncapi_html.md)
+            - confluent
+                - [KafkaBroker](public_api/faststream/confluent/KafkaBroker.md)
+                - [KafkaPublisher](public_api/faststream/confluent/KafkaPublisher.md)
+                - [KafkaResponse](public_api/faststream/confluent/KafkaResponse.md)
+                - [KafkaRoute](public_api/faststream/confluent/KafkaRoute.md)
+                - [KafkaRouter](public_api/faststream/confluent/KafkaRouter.md)
+                - [TestApp](public_api/faststream/confluent/TestApp.md)
+                - [TestKafkaBroker](public_api/faststream/confluent/TestKafkaBroker.md)
             - kafka
                 - [KafkaBroker](public_api/faststream/kafka/KafkaBroker.md)
                 - [KafkaPublisher](public_api/faststream/kafka/KafkaPublisher.md)
@@ -411,6 +419,88 @@ search:
                     - parser
                         - [parse_cli_args](api/faststream/cli/utils/parser/parse_cli_args.md)
                         - [remove_prefix](api/faststream/cli/utils/parser/remove_prefix.md)
+            - confluent
+                - [KafkaBroker](api/faststream/confluent/KafkaBroker.md)
+                - [KafkaPublisher](api/faststream/confluent/KafkaPublisher.md)
+                - [KafkaResponse](api/faststream/confluent/KafkaResponse.md)
+                - [KafkaRoute](api/faststream/confluent/KafkaRoute.md)
+                - [KafkaRouter](api/faststream/confluent/KafkaRouter.md)
+                - [TestApp](api/faststream/confluent/TestApp.md)
+                - [TestKafkaBroker](api/faststream/confluent/TestKafkaBroker.md)
+                - broker
+                    - [KafkaBroker](api/faststream/confluent/broker/KafkaBroker.md)
+                    - broker
+                        - [KafkaBroker](api/faststream/confluent/broker/broker/KafkaBroker.md)
+                    - logging
+                        - [KafkaLoggingBroker](api/faststream/confluent/broker/logging/KafkaLoggingBroker.md)
+                    - registrator
+                        - [KafkaRegistrator](api/faststream/confluent/broker/registrator/KafkaRegistrator.md)
+                - client
+                    - [AsyncConfluentConsumer](api/faststream/confluent/client/AsyncConfluentConsumer.md)
+                    - [AsyncConfluentProducer](api/faststream/confluent/client/AsyncConfluentProducer.md)
+                    - [BatchBuilder](api/faststream/confluent/client/BatchBuilder.md)
+                    - [MsgToSend](api/faststream/confluent/client/MsgToSend.md)
+                    - [TopicPartition](api/faststream/confluent/client/TopicPartition.md)
+                    - [check_msg_error](api/faststream/confluent/client/check_msg_error.md)
+                    - [create_topics](api/faststream/confluent/client/create_topics.md)
+                - fastapi
+                    - [Context](api/faststream/confluent/fastapi/Context.md)
+                    - [KafkaRouter](api/faststream/confluent/fastapi/KafkaRouter.md)
+                    - fastapi
+                        - [KafkaRouter](api/faststream/confluent/fastapi/fastapi/KafkaRouter.md)
+                - message
+                    - [ConsumerProtocol](api/faststream/confluent/message/ConsumerProtocol.md)
+                    - [FakeConsumer](api/faststream/confluent/message/FakeConsumer.md)
+                    - [KafkaMessage](api/faststream/confluent/message/KafkaMessage.md)
+                - opentelemetry
+                    - [KafkaTelemetryMiddleware](api/faststream/confluent/opentelemetry/KafkaTelemetryMiddleware.md)
+                    - middleware
+                        - [KafkaTelemetryMiddleware](api/faststream/confluent/opentelemetry/middleware/KafkaTelemetryMiddleware.md)
+                    - provider
+                        - [BaseConfluentTelemetrySettingsProvider](api/faststream/confluent/opentelemetry/provider/BaseConfluentTelemetrySettingsProvider.md)
+                        - [BatchConfluentTelemetrySettingsProvider](api/faststream/confluent/opentelemetry/provider/BatchConfluentTelemetrySettingsProvider.md)
+                        - [ConfluentTelemetrySettingsProvider](api/faststream/confluent/opentelemetry/provider/ConfluentTelemetrySettingsProvider.md)
+                        - [telemetry_attributes_provider_factory](api/faststream/confluent/opentelemetry/provider/telemetry_attributes_provider_factory.md)
+                - parser
+                    - [AsyncConfluentParser](api/faststream/confluent/parser/AsyncConfluentParser.md)
+                - publisher
+                    - asyncapi
+                        - [AsyncAPIBatchPublisher](api/faststream/confluent/publisher/asyncapi/AsyncAPIBatchPublisher.md)
+                        - [AsyncAPIDefaultPublisher](api/faststream/confluent/publisher/asyncapi/AsyncAPIDefaultPublisher.md)
+                        - [AsyncAPIPublisher](api/faststream/confluent/publisher/asyncapi/AsyncAPIPublisher.md)
+                    - producer
+                        - [AsyncConfluentFastProducer](api/faststream/confluent/publisher/producer/AsyncConfluentFastProducer.md)
+                    - usecase
+                        - [BatchPublisher](api/faststream/confluent/publisher/usecase/BatchPublisher.md)
+                        - [DefaultPublisher](api/faststream/confluent/publisher/usecase/DefaultPublisher.md)
+                        - [LogicPublisher](api/faststream/confluent/publisher/usecase/LogicPublisher.md)
+                - response
+                    - [KafkaResponse](api/faststream/confluent/response/KafkaResponse.md)
+                - router
+                    - [KafkaPublisher](api/faststream/confluent/router/KafkaPublisher.md)
+                    - [KafkaRoute](api/faststream/confluent/router/KafkaRoute.md)
+                    - [KafkaRouter](api/faststream/confluent/router/KafkaRouter.md)
+                - schemas
+                    - params
+                        - [ConsumerConnectionParams](api/faststream/confluent/schemas/params/ConsumerConnectionParams.md)
+                - security
+                    - [parse_security](api/faststream/confluent/security/parse_security.md)
+                - subscriber
+                    - asyncapi
+                        - [AsyncAPIBatchSubscriber](api/faststream/confluent/subscriber/asyncapi/AsyncAPIBatchSubscriber.md)
+                        - [AsyncAPIDefaultSubscriber](api/faststream/confluent/subscriber/asyncapi/AsyncAPIDefaultSubscriber.md)
+                        - [AsyncAPISubscriber](api/faststream/confluent/subscriber/asyncapi/AsyncAPISubscriber.md)
+                    - factory
+                        - [create_subscriber](api/faststream/confluent/subscriber/factory/create_subscriber.md)
+                    - usecase
+                        - [BatchSubscriber](api/faststream/confluent/subscriber/usecase/BatchSubscriber.md)
+                        - [DefaultSubscriber](api/faststream/confluent/subscriber/usecase/DefaultSubscriber.md)
+                        - [LogicSubscriber](api/faststream/confluent/subscriber/usecase/LogicSubscriber.md)
+                - testing
+                    - [FakeProducer](api/faststream/confluent/testing/FakeProducer.md)
+                    - [MockConfluentMessage](api/faststream/confluent/testing/MockConfluentMessage.md)
+                    - [TestKafkaBroker](api/faststream/confluent/testing/TestKafkaBroker.md)
+                    - [build_message](api/faststream/confluent/testing/build_message.md)
             - constants
                 - [ContentTypes](api/faststream/constants/ContentTypes.md)
             - exceptions

--- a/docs/docs/en/api/faststream/Response.md
+++ b/docs/docs/en/api/faststream/Response.md
@@ -1,0 +1,11 @@
+---
+# 0.5 - API
+# 2 - Release
+# 3 - Contributing
+# 5 - Template Page
+# 10 - Default
+search:
+  boost: 0.5
+---
+
+::: faststream.Response

--- a/docs/docs/en/api/faststream/broker/response/Response.md
+++ b/docs/docs/en/api/faststream/broker/response/Response.md
@@ -1,0 +1,11 @@
+---
+# 0.5 - API
+# 2 - Release
+# 3 - Contributing
+# 5 - Template Page
+# 10 - Default
+search:
+  boost: 0.5
+---
+
+::: faststream.broker.response.Response

--- a/docs/docs/en/api/faststream/confluent/KafkaResponse.md
+++ b/docs/docs/en/api/faststream/confluent/KafkaResponse.md
@@ -1,0 +1,11 @@
+---
+# 0.5 - API
+# 2 - Release
+# 3 - Contributing
+# 5 - Template Page
+# 10 - Default
+search:
+  boost: 0.5
+---
+
+::: faststream.confluent.KafkaResponse

--- a/docs/docs/en/api/faststream/confluent/response/KafkaResponse.md
+++ b/docs/docs/en/api/faststream/confluent/response/KafkaResponse.md
@@ -1,0 +1,11 @@
+---
+# 0.5 - API
+# 2 - Release
+# 3 - Contributing
+# 5 - Template Page
+# 10 - Default
+search:
+  boost: 0.5
+---
+
+::: faststream.confluent.response.KafkaResponse

--- a/docs/docs/en/api/faststream/kafka/KafkaResponse.md
+++ b/docs/docs/en/api/faststream/kafka/KafkaResponse.md
@@ -1,0 +1,11 @@
+---
+# 0.5 - API
+# 2 - Release
+# 3 - Contributing
+# 5 - Template Page
+# 10 - Default
+search:
+  boost: 0.5
+---
+
+::: faststream.kafka.KafkaResponse

--- a/docs/docs/en/api/faststream/kafka/response/KafkaResponse.md
+++ b/docs/docs/en/api/faststream/kafka/response/KafkaResponse.md
@@ -1,0 +1,11 @@
+---
+# 0.5 - API
+# 2 - Release
+# 3 - Contributing
+# 5 - Template Page
+# 10 - Default
+search:
+  boost: 0.5
+---
+
+::: faststream.kafka.response.KafkaResponse

--- a/docs/docs/en/api/faststream/nats/NatsResponse.md
+++ b/docs/docs/en/api/faststream/nats/NatsResponse.md
@@ -1,0 +1,11 @@
+---
+# 0.5 - API
+# 2 - Release
+# 3 - Contributing
+# 5 - Template Page
+# 10 - Default
+search:
+  boost: 0.5
+---
+
+::: faststream.nats.NatsResponse

--- a/docs/docs/en/api/faststream/nats/response/NatsResponse.md
+++ b/docs/docs/en/api/faststream/nats/response/NatsResponse.md
@@ -1,0 +1,11 @@
+---
+# 0.5 - API
+# 2 - Release
+# 3 - Contributing
+# 5 - Template Page
+# 10 - Default
+search:
+  boost: 0.5
+---
+
+::: faststream.nats.response.NatsResponse

--- a/docs/docs/en/api/faststream/rabbit/RabbitResponse.md
+++ b/docs/docs/en/api/faststream/rabbit/RabbitResponse.md
@@ -1,0 +1,11 @@
+---
+# 0.5 - API
+# 2 - Release
+# 3 - Contributing
+# 5 - Template Page
+# 10 - Default
+search:
+  boost: 0.5
+---
+
+::: faststream.rabbit.RabbitResponse

--- a/docs/docs/en/api/faststream/rabbit/response/RabbitResponse.md
+++ b/docs/docs/en/api/faststream/rabbit/response/RabbitResponse.md
@@ -1,0 +1,11 @@
+---
+# 0.5 - API
+# 2 - Release
+# 3 - Contributing
+# 5 - Template Page
+# 10 - Default
+search:
+  boost: 0.5
+---
+
+::: faststream.rabbit.response.RabbitResponse

--- a/docs/docs/en/api/faststream/redis/RedisResponse.md
+++ b/docs/docs/en/api/faststream/redis/RedisResponse.md
@@ -1,0 +1,11 @@
+---
+# 0.5 - API
+# 2 - Release
+# 3 - Contributing
+# 5 - Template Page
+# 10 - Default
+search:
+  boost: 0.5
+---
+
+::: faststream.redis.RedisResponse

--- a/docs/docs/en/api/faststream/redis/response/RedisResponse.md
+++ b/docs/docs/en/api/faststream/redis/response/RedisResponse.md
@@ -1,0 +1,11 @@
+---
+# 0.5 - API
+# 2 - Release
+# 3 - Contributing
+# 5 - Template Page
+# 10 - Default
+search:
+  boost: 0.5
+---
+
+::: faststream.redis.response.RedisResponse

--- a/faststream/__about__.py
+++ b/faststream/__about__.py
@@ -1,6 +1,6 @@
 """Simple and fast framework to create message brokers based microservices."""
 
-__version__ = "0.5.9"
+__version__ = "0.5.10"
 
 SERVICE_NAME = f"faststream-{__version__}"
 

--- a/faststream/__init__.py
+++ b/faststream/__init__.py
@@ -3,6 +3,7 @@
 from faststream.annotations import ContextRepo, Logger, NoCast
 from faststream.app import FastStream
 from faststream.broker.middlewares import BaseMiddleware
+from faststream.broker.response import Response
 from faststream.testing.app import TestApp
 from faststream.utils import Context, Depends, Header, Path, apply_types, context
 
@@ -23,4 +24,6 @@ __all__ = (
     "NoCast",
     # middlewares
     "BaseMiddleware",
+    # basic
+    "Response",
 )

--- a/faststream/broker/response.py
+++ b/faststream/broker/response.py
@@ -1,0 +1,52 @@
+from typing import TYPE_CHECKING, Any, Optional, Union
+
+if TYPE_CHECKING:
+    from faststream.types import AnyDict, SendableMessage
+
+
+class Response:
+    def __new__(
+        cls,
+        body: Union[
+            "SendableMessage",
+            "Response",
+        ],
+        **kwargs: Any,
+    ) -> "Response":
+        """Create a new instance of the class."""
+        if isinstance(body, cls):
+            return body
+
+        else:
+            return super().__new__(cls)
+
+    def __init__(
+        self,
+        body: "SendableMessage",
+        *,
+        headers: Optional["AnyDict"] = None,
+        correlation_id: Optional[str] = None,
+    ) -> None:
+        """Initialize a handler."""
+        if not isinstance(body, Response):
+            self.body = body
+            self.headers = headers or {}
+            self.correlation_id = correlation_id
+
+    def add_headers(
+        self,
+        extra_headers: "AnyDict",
+        *,
+        override: bool = True,
+    ) -> None:
+        if override:
+            self.headers = {**self.headers, **extra_headers}
+        else:
+            self.headers = {**extra_headers, **self.headers}
+
+    def as_publish_kwargs(self) -> "AnyDict":
+        publish_options = {
+            "headers": self.headers,
+            "correlation_id": self.correlation_id,
+        }
+        return publish_options

--- a/faststream/confluent/__init__.py
+++ b/faststream/confluent/__init__.py
@@ -1,5 +1,6 @@
 from faststream.confluent.annotations import KafkaMessage
 from faststream.confluent.broker import KafkaBroker
+from faststream.confluent.response import KafkaResponse
 from faststream.confluent.router import KafkaPublisher, KafkaRoute, KafkaRouter
 from faststream.confluent.testing import TestKafkaBroker
 from faststream.testing.app import TestApp
@@ -10,6 +11,7 @@ __all__ = (
     "KafkaRouter",
     "KafkaRoute",
     "KafkaPublisher",
+    "KafkaResponse",
     "TestKafkaBroker",
     "TestApp",
 )

--- a/faststream/confluent/response.py
+++ b/faststream/confluent/response.py
@@ -1,0 +1,5 @@
+from faststream.broker.response import Response
+
+
+class KafkaResponse(Response):
+    pass

--- a/faststream/kafka/__init__.py
+++ b/faststream/kafka/__init__.py
@@ -2,6 +2,7 @@ from aiokafka import TopicPartition
 
 from faststream.kafka.annotations import KafkaMessage
 from faststream.kafka.broker import KafkaBroker
+from faststream.kafka.response import KafkaResponse
 from faststream.kafka.router import KafkaPublisher, KafkaRoute, KafkaRouter
 from faststream.kafka.testing import TestKafkaBroker
 from faststream.testing.app import TestApp
@@ -11,6 +12,7 @@ __all__ = (
     "KafkaMessage",
     "KafkaRouter",
     "KafkaRoute",
+    "KafkaResponse",
     "KafkaPublisher",
     "TestKafkaBroker",
     "TestApp",

--- a/faststream/kafka/response.py
+++ b/faststream/kafka/response.py
@@ -1,0 +1,5 @@
+from faststream.broker.response import Response
+
+
+class KafkaResponse(Response):
+    pass

--- a/faststream/nats/__init__.py
+++ b/faststream/nats/__init__.py
@@ -15,6 +15,7 @@ from nats.js.api import (
 
 from faststream.nats.annotations import NatsMessage
 from faststream.nats.broker.broker import NatsBroker
+from faststream.nats.response import NatsResponse
 from faststream.nats.router import NatsPublisher, NatsRoute, NatsRouter
 from faststream.nats.schemas import JStream, KvWatch, ObjWatch, PullSub
 from faststream.nats.testing import TestNatsBroker
@@ -32,6 +33,7 @@ __all__ = (
     "NatsPublisher",
     "TestNatsBroker",
     "NatsMessage",
+    "NatsResponse",
     # Nats imports
     "ConsumerConfig",
     "DeliverPolicy",

--- a/faststream/nats/response.py
+++ b/faststream/nats/response.py
@@ -1,0 +1,5 @@
+from faststream.broker.response import Response
+
+
+class NatsResponse(Response):
+    pass

--- a/faststream/rabbit/__init__.py
+++ b/faststream/rabbit/__init__.py
@@ -1,5 +1,6 @@
 from faststream.rabbit.annotations import RabbitMessage
 from faststream.rabbit.broker import RabbitBroker
+from faststream.rabbit.response import RabbitResponse
 from faststream.rabbit.router import RabbitPublisher, RabbitRoute, RabbitRouter
 from faststream.rabbit.schemas import (
     ExchangeType,
@@ -17,6 +18,7 @@ __all__ = (
     "RabbitRouter",
     "RabbitRoute",
     "RabbitPublisher",
+    "RabbitResponse",
     "ExchangeType",
     "ReplyConfig",
     "RabbitExchange",

--- a/faststream/rabbit/publisher/asyncapi.py
+++ b/faststream/rabbit/publisher/asyncapi.py
@@ -32,7 +32,6 @@ class AsyncAPIPublisher(LogicPublisher):
     # or
     publisher: AsyncAPIPublisher = router.publisher(...)
     ```
-
     """
 
     def get_name(self) -> str:

--- a/faststream/rabbit/response.py
+++ b/faststream/rabbit/response.py
@@ -1,0 +1,5 @@
+from faststream.broker.response import Response
+
+
+class RabbitResponse(Response):
+    pass

--- a/faststream/rabbit/testing.py
+++ b/faststream/rabbit/testing.py
@@ -49,7 +49,7 @@ class TestRabbitBroker(TestBroker[RabbitBroker]):
         publisher: AsyncAPIPublisher,
     ) -> "HandlerCallWrapper[Any, Any, Any]":
         sub = broker.subscriber(
-            queue=publisher.queue,
+            queue=publisher.routing,
             exchange=publisher.exchange,
         )
 
@@ -70,7 +70,7 @@ class TestRabbitBroker(TestBroker[RabbitBroker]):
     ) -> None:
         broker._subscribers.pop(
             AsyncAPISubscriber.get_routing_hash(
-                queue=publisher.queue,
+                queue=RabbitQueue.validate(publisher.routing),
                 exchange=publisher.exchange,
             ),
             None,
@@ -132,7 +132,7 @@ def build_message(
         priority=priority,
         correlation_id=correlation_id,
         expiration=expiration,
-        message_id=message_id,
+        message_id=message_id or gen_cor_id(),
         timestamp=timestamp,
         message_type=message_type,
         user_id=user_id,
@@ -148,14 +148,21 @@ def build_message(
             header=ContentHeader(
                 properties=spec.Basic.Properties(
                     content_type=msg.content_type,
-                    message_id=gen_cor_id(),
                     headers=msg.headers,
-                    reply_to=reply_to,
+                    reply_to=msg.reply_to,
+                    content_encoding=msg.content_encoding,
+                    priority=msg.priority,
+                    correlation_id=msg.correlation_id,
+                    message_id=msg.message_id,
+                    timestamp=msg.timestamp,
+                    message_type=message_type,
+                    user_id=msg.user_id,
+                    app_id=msg.app_id,
                 )
             ),
             body=msg.body,
             channel=AsyncMock(),
-        )
+        ),
     )
 
 

--- a/faststream/redis/__init__.py
+++ b/faststream/redis/__init__.py
@@ -1,5 +1,6 @@
 from faststream.redis.annotations import Redis, RedisMessage
 from faststream.redis.broker.broker import RedisBroker
+from faststream.redis.response import RedisResponse
 from faststream.redis.router import RedisPublisher, RedisRoute, RedisRouter
 from faststream.redis.schemas import ListSub, PubSub, StreamSub
 from faststream.redis.testing import TestRedisBroker
@@ -12,6 +13,7 @@ __all__ = (
     "RedisRoute",
     "RedisRouter",
     "RedisPublisher",
+    "RedisResponse",
     "TestRedisBroker",
     "TestApp",
     "PubSub",

--- a/faststream/redis/publisher/usecase.py
+++ b/faststream/redis/publisher/usecase.py
@@ -282,7 +282,6 @@ class ListPublisher(LogicPublisher):
 
         list_sub = ListSub.validate(list or self.list)
         reply_to = reply_to or self.reply_to
-        headers = headers or self.headers
         correlation_id = correlation_id or gen_cor_id()
 
         call: "AsyncFunc" = self._producer.publish
@@ -301,7 +300,7 @@ class ListPublisher(LogicPublisher):
             list=list_sub.name,
             # basic args
             reply_to=reply_to,
-            headers=headers,
+            headers=headers or self.headers,
             correlation_id=correlation_id,
             # RPC args
             rpc=rpc,
@@ -326,6 +325,10 @@ class ListBatchPublisher(ListPublisher):
         correlation_id: Annotated[
             Optional[str],
             Doc("Has no real effect. Option to be compatible with original protocol."),
+        ] = None,
+        headers: Annotated[
+            Optional["AnyDict"],
+            Doc("Message headers to store metainformation."),
         ] = None,
         # publisher specific
         _extra_middlewares: Annotated[
@@ -353,6 +356,7 @@ class ListBatchPublisher(ListPublisher):
             *message,
             list=list_sub.name,
             correlation_id=correlation_id,
+            headers=headers or self.headers,
         )
 
 

--- a/faststream/redis/response.py
+++ b/faststream/redis/response.py
@@ -1,0 +1,5 @@
+from faststream.broker.response import Response
+
+
+class RedisResponse(Response):
+    pass

--- a/tests/brokers/rabbit/test_test_client.py
+++ b/tests/brokers/rabbit/test_test_client.py
@@ -61,6 +61,18 @@ class TestTestclient(BrokerTestclientTestcase):
 
         assert event.is_set()
 
+    async def test_respect_routing_key(self):
+        broker = self.get_broker()
+
+        publisher = broker.publisher(
+            exchange=RabbitExchange("test", type=ExchangeType.TOPIC), routing_key="up"
+        )
+
+        async with TestRabbitBroker(broker):
+            await publisher.publish("Hi!")
+
+            publisher.mock.assert_called_once_with("Hi!")
+
     async def test_direct(
         self,
         queue: str,

--- a/tests/brokers/test_response.py
+++ b/tests/brokers/test_response.py
@@ -1,0 +1,25 @@
+from faststream.broker.response import Response
+
+
+def test_raw_data():
+    resp = Response(1)
+    assert resp.body == 1
+    assert resp.headers == {}
+
+
+def test_response_with_response_instance():
+    resp = Response(Response(1, headers={"some": 1}))
+    assert resp.body == 1
+    assert resp.headers == {"some": 1}
+
+
+def test_headers_override():
+    resp = Response(1, headers={"some": 1})
+    resp.add_headers({"some": 2})
+    assert resp.headers == {"some": 2}
+
+
+def test_headers_with_default():
+    resp = Response(1, headers={"some": 1})
+    resp.add_headers({"some": 2}, override=False)
+    assert resp.headers == {"some": 1}


### PR DESCRIPTION
# Description

Now you can return `Response` class to set more specific outgoing message parameters:

```python
from faststream import Response

@broker.subscriber("in")
@broker.subscriber("out")
async def handler():
    return Response(body=b"", headers={})
```

Close #1431, fix #1480

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [x] Bug fix (a non-breaking change that resolves an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
