### PR TITLE
Resolve Issue 1386, Add rpc_prefix

### DIFF
--- a/docs/docs/SUMMARY.md
+++ b/docs/docs/SUMMARY.md
@@ -1007,6 +1007,8 @@ search:
                     - [to_async](api/faststream/utils/functions/to_async.md)
                 - no_cast
                     - [NoCast](api/faststream/utils/no_cast/NoCast.md)
+                - nuid
+                    - [NUID](api/faststream/utils/nuid/NUID.md)
                 - path
                     - [compile_path](api/faststream/utils/path/compile_path.md)
 - Contributing

--- a/docs/docs/en/api/faststream/utils/nuid/NUID.md
+++ b/docs/docs/en/api/faststream/utils/nuid/NUID.md
@@ -1,0 +1,11 @@
+---
+# 0.5 - API
+# 2 - Release
+# 3 - Contributing
+# 5 - Template Page
+# 10 - Default
+search:
+  boost: 0.5
+---
+
+::: faststream.utils.nuid.NUID

--- a/faststream/nats/publisher/producer.py
+++ b/faststream/nats/publisher/producer.py
@@ -73,7 +73,6 @@ class NatsFastProducer(ProducerProto):
 
             reply_to = client.new_inbox()
 
-
             future: asyncio.Future[Msg] = asyncio.Future()
             sub = await client.subscribe(reply_to, future=future, max_msgs=1)
             await sub.unsubscribe(limit=1)
@@ -133,7 +132,6 @@ class NatsJSFastProducer(ProducerProto):
         stream: Optional[str] = None,
         timeout: Optional[float] = None,
         rpc: bool = False,
-        rpc_prefix: str = "",
         rpc_timeout: Optional[float] = 30.0,
         raise_timeout: bool = False,
     ) -> Optional[Any]:
@@ -148,9 +146,7 @@ class NatsJSFastProducer(ProducerProto):
         if rpc:
             if reply_to:
                 raise WRONG_PUBLISH_ARGS
-            nuid = NUID()
-            rpc_nuid = str(nuid.next(), "utf-8")
-            reply_to = f"{rpc_prefix}{rpc_nuid}"
+            reply_to = self._connection._nc.new_inbox()
             future: asyncio.Future[Msg] = asyncio.Future()
             sub = await self._connection._nc.subscribe(
                 reply_to, future=future, max_msgs=1

--- a/faststream/nats/publisher/producer.py
+++ b/faststream/nats/publisher/producer.py
@@ -135,7 +135,7 @@ class NatsJSFastProducer(ProducerProto):
         stream: Optional[str] = None,
         timeout: Optional[float] = None,
         rpc: bool = False,
-        reply_to_prefix: str = "",
+        rpc_prefix: str = "",
         rpc_timeout: Optional[float] = 30.0,
         raise_timeout: bool = False,
     ) -> Optional[Any]:
@@ -152,7 +152,7 @@ class NatsJSFastProducer(ProducerProto):
                 raise WRONG_PUBLISH_ARGS
             nuid = NUID()
             rpc_nuid = str(nuid.next(),"utf-8")
-            reply_to = f"{reply_to_prefix}{rpc_nuid}"
+            reply_to = f"{rpc_prefix}{rpc_nuid}"
             future: asyncio.Future[Msg] = asyncio.Future()
             sub = await self._connection._nc.subscribe(
                 reply_to, future=future, max_msgs=1

--- a/faststream/nats/publisher/producer.py
+++ b/faststream/nats/publisher/producer.py
@@ -134,7 +134,7 @@ class NatsJSFastProducer(ProducerProto):
         stream: Optional[str] = None,
         timeout: Optional[float] = None,
         rpc: bool = False,
-        reply_to_prefix: str = ""
+        reply_to_prefix: str = "",
         rpc_timeout: Optional[float] = 30.0,
         raise_timeout: bool = False,
     ) -> Optional[Any]:

--- a/faststream/nats/publisher/producer.py
+++ b/faststream/nats/publisher/producer.py
@@ -52,7 +52,6 @@ class NatsFastProducer(ProducerProto):
         *,
         correlation_id: str,
         headers: Optional[Dict[str, str]] = None,
-        reply_to: str = "",
         rpc: bool = False,
         rpc_timeout: Optional[float] = 30.0,
         raise_timeout: bool = False,
@@ -71,9 +70,8 @@ class NatsFastProducer(ProducerProto):
             if reply_to:
                 raise WRONG_PUBLISH_ARGS
 
-            token = client._nuid.next()
-            token.extend(token_hex(2).encode())
-            reply_to = token.decode()
+            reply_to = client.new_inbox()
+
 
             future: asyncio.Future[Msg] = asyncio.Future()
             sub = await client.subscribe(reply_to, future=future, max_msgs=1)

--- a/faststream/nats/publisher/producer.py
+++ b/faststream/nats/publisher/producer.py
@@ -52,6 +52,7 @@ class NatsFastProducer(ProducerProto):
         *,
         correlation_id: str,
         headers: Optional[Dict[str, str]] = None,
+        reply_to: str = "",
         rpc: bool = False,
         rpc_timeout: Optional[float] = 30.0,
         raise_timeout: bool = False,

--- a/faststream/nats/publisher/producer.py
+++ b/faststream/nats/publisher/producer.py
@@ -1,9 +1,7 @@
 import asyncio
 from secrets import token_hex
 from typing import TYPE_CHECKING, Any, Dict, Optional
-from uuid import uuid4
 
-from faststream.utils.nuid import NUID
 import nats
 from typing_extensions import override
 
@@ -13,6 +11,7 @@ from faststream.broker.utils import resolve_custom_func
 from faststream.exceptions import WRONG_PUBLISH_ARGS
 from faststream.nats.parser import NatsParser
 from faststream.utils.functions import timeout_scope
+from faststream.utils.nuid import NUID
 
 if TYPE_CHECKING:
     from nats.aio.client import Client
@@ -151,7 +150,7 @@ class NatsJSFastProducer(ProducerProto):
             if reply_to:
                 raise WRONG_PUBLISH_ARGS
             nuid = NUID()
-            rpc_nuid = str(nuid.next(),"utf-8")
+            rpc_nuid = str(nuid.next(), "utf-8")
             reply_to = f"{rpc_prefix}{rpc_nuid}"
             future: asyncio.Future[Msg] = asyncio.Future()
             sub = await self._connection._nc.subscribe(

--- a/faststream/nats/publisher/producer.py
+++ b/faststream/nats/publisher/producer.py
@@ -1,5 +1,4 @@
 import asyncio
-from secrets import token_hex
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import nats
@@ -11,7 +10,6 @@ from faststream.broker.utils import resolve_custom_func
 from faststream.exceptions import WRONG_PUBLISH_ARGS
 from faststream.nats.parser import NatsParser
 from faststream.utils.functions import timeout_scope
-from faststream.utils.nuid import NUID
 
 if TYPE_CHECKING:
     from nats.aio.client import Client

--- a/faststream/nats/publisher/producer.py
+++ b/faststream/nats/publisher/producer.py
@@ -3,6 +3,7 @@ from secrets import token_hex
 from typing import TYPE_CHECKING, Any, Dict, Optional
 from uuid import uuid4
 
+from faststream.utils.nuid import NUID
 import nats
 from typing_extensions import override
 
@@ -150,7 +151,8 @@ class NatsJSFastProducer(ProducerProto):
             if reply_to:
                 raise WRONG_PUBLISH_ARGS
             nuid = NUID()
-            reply_to = f"{reply_to_prefix}{str(nuid.next(),"utf-8")})"
+            rpc_nuid = str(nuid.next(),"utf-8")
+            reply_to = f"{reply_to_prefix}{rpc_nuid}"
             future: asyncio.Future[Msg] = asyncio.Future()
             sub = await self._connection._nc.subscribe(
                 reply_to, future=future, max_msgs=1

--- a/faststream/nats/publisher/producer.py
+++ b/faststream/nats/publisher/producer.py
@@ -134,6 +134,7 @@ class NatsJSFastProducer(ProducerProto):
         stream: Optional[str] = None,
         timeout: Optional[float] = None,
         rpc: bool = False,
+        reply_to_prefix: str = ""
         rpc_timeout: Optional[float] = 30.0,
         raise_timeout: bool = False,
     ) -> Optional[Any]:
@@ -148,8 +149,8 @@ class NatsJSFastProducer(ProducerProto):
         if rpc:
             if reply_to:
                 raise WRONG_PUBLISH_ARGS
-
-            reply_to = str(uuid4())
+            nuid = NUID()
+            reply_to = f"{reply_to_prefix}{str(nuid.next(),"utf-8")})"
             future: asyncio.Future[Msg] = asyncio.Future()
             sub = await self._connection._nc.subscribe(
                 reply_to, future=future, max_msgs=1

--- a/faststream/redis/publisher/producer.py
+++ b/faststream/redis/publisher/producer.py
@@ -57,7 +57,7 @@ class RedisFastProducer(ProducerProto):
         maxlen: Optional[int] = None,
         headers: Optional["AnyDict"] = None,
         reply_to: str = "",
-        reply_to_prefix: str = "",
+        rpc_prefix: str = "",
         rpc: bool = False,
         rpc_timeout: Optional[float] = 30.0,
         raise_timeout: bool = False,
@@ -71,7 +71,7 @@ class RedisFastProducer(ProducerProto):
                 raise WRONG_PUBLISH_ARGS
             nuid = NUID()
             rpc_nuid = str(nuid.next(),"utf-8")
-            reply_to = f"{reply_to_prefix}{rpc_nuid}"
+            reply_to = f"{rpc_prefix}{rpc_nuid}"
             psub = self._connection.pubsub()
             await psub.subscribe(reply_to)
 

--- a/faststream/redis/publisher/producer.py
+++ b/faststream/redis/publisher/producer.py
@@ -56,7 +56,6 @@ class RedisFastProducer(ProducerProto):
         maxlen: Optional[int] = None,
         headers: Optional["AnyDict"] = None,
         reply_to: str = "",
-        rpc_prefix: str = "",
         rpc: bool = False,
         rpc_timeout: Optional[float] = 30.0,
         raise_timeout: bool = False,
@@ -70,7 +69,7 @@ class RedisFastProducer(ProducerProto):
                 raise WRONG_PUBLISH_ARGS
             nuid = NUID()
             rpc_nuid = str(nuid.next(), "utf-8")
-            reply_to = f"{rpc_prefix}{rpc_nuid}"
+            reply_to = rpc_nuid
             psub = self._connection.pubsub()
             await psub.subscribe(reply_to)
 

--- a/faststream/redis/publisher/producer.py
+++ b/faststream/redis/publisher/producer.py
@@ -56,7 +56,7 @@ class RedisFastProducer(ProducerProto):
         maxlen: Optional[int] = None,
         headers: Optional["AnyDict"] = None,
         reply_to: str = "",
-        reply_to_prefix: str = ""
+        reply_to_prefix: str = "",
         rpc: bool = False,
         rpc_timeout: Optional[float] = 30.0,
         raise_timeout: bool = False,

--- a/faststream/redis/publisher/producer.py
+++ b/faststream/redis/publisher/producer.py
@@ -1,5 +1,4 @@
 from typing import TYPE_CHECKING, Any, Optional
-from uuid import uuid4
 
 from typing_extensions import override
 
@@ -70,7 +69,7 @@ class RedisFastProducer(ProducerProto):
             if reply_to:
                 raise WRONG_PUBLISH_ARGS
             nuid = NUID()
-            rpc_nuid = str(nuid.next(),"utf-8")
+            rpc_nuid = str(nuid.next(), "utf-8")
             reply_to = f"{rpc_prefix}{rpc_nuid}"
             psub = self._connection.pubsub()
             await psub.subscribe(reply_to)

--- a/faststream/redis/publisher/producer.py
+++ b/faststream/redis/publisher/producer.py
@@ -10,6 +10,7 @@ from faststream.redis.message import DATA_KEY
 from faststream.redis.parser import RawMessage, RedisPubSubParser
 from faststream.redis.schemas import INCORRECT_SETUP_MSG
 from faststream.utils.functions import timeout_scope
+from faststream.utils.nuid import NUID
 
 if TYPE_CHECKING:
     from redis.asyncio.client import PubSub, Redis
@@ -69,7 +70,8 @@ class RedisFastProducer(ProducerProto):
             if reply_to:
                 raise WRONG_PUBLISH_ARGS
             nuid = NUID()
-            reply_to = f"{reply_to_prefix}{str(nuid.next(),"utf-8")})"
+            rpc_nuid = str(nuid.next(),"utf-8")
+            reply_to = f"{reply_to_prefix}{rpc_nuid}"
             psub = self._connection.pubsub()
             await psub.subscribe(reply_to)
 

--- a/faststream/redis/publisher/producer.py
+++ b/faststream/redis/publisher/producer.py
@@ -56,6 +56,7 @@ class RedisFastProducer(ProducerProto):
         maxlen: Optional[int] = None,
         headers: Optional["AnyDict"] = None,
         reply_to: str = "",
+        reply_to_prefix: str = ""
         rpc: bool = False,
         rpc_timeout: Optional[float] = 30.0,
         raise_timeout: bool = False,
@@ -67,8 +68,8 @@ class RedisFastProducer(ProducerProto):
         if rpc:
             if reply_to:
                 raise WRONG_PUBLISH_ARGS
-
-            reply_to = str(uuid4())
+            nuid = NUID()
+            reply_to = f"{reply_to_prefix}{str(nuid.next(),"utf-8")})"
             psub = self._connection.pubsub()
             await psub.subscribe(reply_to)
 

--- a/faststream/utils/nuid.py
+++ b/faststream/utils/nuid.py
@@ -1,0 +1,70 @@
+# Copyright 2016-2018 The NATS Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+from random import Random
+from secrets import randbelow, token_bytes
+from sys import maxsize as MaxInt
+
+DIGITS = b'0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+BASE = 62
+PREFIX_LENGTH = 12
+SEQ_LENGTH = 10
+MAX_SEQ = 839299365868340224  # BASE**10
+MIN_INC = 33
+MAX_INC = 333
+INC = MAX_INC - MIN_INC
+TOTAL_LENGTH = PREFIX_LENGTH + SEQ_LENGTH
+
+
+class NUID:
+    """
+    NUID is an implementation of the approach for fast generation of
+    unique identifiers used for inboxes in NATS.
+    """
+
+    def __init__(self) -> None:
+        self._prand = Random(randbelow(MaxInt))
+        self._seq = self._prand.randint(0, MAX_SEQ)
+        self._inc = MIN_INC + self._prand.randint(BASE + 1, INC)
+        self._prefix = bytearray()
+        self.randomize_prefix()
+
+    def next(self) -> bytearray:
+        """
+        next returns the next unique identifier.
+        """
+        self._seq += self._inc
+        if self._seq >= MAX_SEQ:
+            self.randomize_prefix()
+            self.reset_sequential()
+
+        l = self._seq
+        prefix = self._prefix[:]
+        suffix = bytearray(SEQ_LENGTH)
+        for i in reversed(range(SEQ_LENGTH)):
+            suffix[i] = DIGITS[int(l) % BASE]
+            l //= BASE
+
+        prefix.extend(suffix)
+        return prefix
+
+    def randomize_prefix(self) -> None:
+        random_bytes = token_bytes(PREFIX_LENGTH)
+        self._prefix = bytearray(DIGITS[c % BASE] for c in random_bytes)
+
+    def reset_sequential(self) -> None:
+        self._seq = self._prand.randint(0, MAX_SEQ)
+        self._inc = MIN_INC + self._prand.randint(0, INC)

--- a/faststream/utils/nuid.py
+++ b/faststream/utils/nuid.py
@@ -10,7 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 from __future__ import annotations
 
@@ -37,7 +36,7 @@ class NUID:
     """
 
     def __init__(self) -> None:
-        self._prand = Random(randbelow(max_int))
+        self._prand = Random(randbelow(max_int))  # nosec B311
         self._seq = self._prand.randint(0, MAX_SEQ)
         self._inc = MIN_INC + self._prand.randint(BASE + 1, INC)
         self._prefix = bytearray()

--- a/faststream/utils/nuid.py
+++ b/faststream/utils/nuid.py
@@ -16,9 +16,9 @@ from __future__ import annotations
 
 from random import Random
 from secrets import randbelow, token_bytes
-from sys import maxsize as MaxInt
+from sys import maxsize as max_int
 
-DIGITS = b'0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+DIGITS = b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 BASE = 62
 PREFIX_LENGTH = 12
 SEQ_LENGTH = 10
@@ -30,33 +30,32 @@ TOTAL_LENGTH = PREFIX_LENGTH + SEQ_LENGTH
 
 
 class NUID:
-    """
-    NUID is an implementation of the approach for fast generation of
-    unique identifiers used for inboxes in NATS.
+    """NUID created is a utility to create a new id.
+
+    NUID is an implementation of the approach for fast generation
+    of unique identifiers used for inboxes in NATS.
     """
 
     def __init__(self) -> None:
-        self._prand = Random(randbelow(MaxInt))
+        self._prand = Random(randbelow(max_int))
         self._seq = self._prand.randint(0, MAX_SEQ)
         self._inc = MIN_INC + self._prand.randint(BASE + 1, INC)
         self._prefix = bytearray()
         self.randomize_prefix()
 
     def next(self) -> bytearray:
-        """
-        next returns the next unique identifier.
-        """
+        """Next returns the next unique identifier."""
         self._seq += self._inc
         if self._seq >= MAX_SEQ:
             self.randomize_prefix()
             self.reset_sequential()
 
-        l = self._seq
+        l_seq = self._seq
         prefix = self._prefix[:]
         suffix = bytearray(SEQ_LENGTH)
         for i in reversed(range(SEQ_LENGTH)):
-            suffix[i] = DIGITS[int(l) % BASE]
-            l //= BASE
+            suffix[i] = DIGITS[int(l_seq) % BASE]
+            l_seq //= BASE
 
         prefix.extend(suffix)
         return prefix

--- a/tests/brokers/nats/test_test_client.py
+++ b/tests/brokers/nats/test_test_client.py
@@ -80,6 +80,18 @@ class TestTestclient(BrokerTestclientTestcase):
 
         assert event.is_set()
 
+    @pytest.mark.nats()
+    async def test_inbox_prefix_with_real(
+        self,
+        queue: str,
+    ):
+        broker = NatsBroker(inbox_prefix="test")
+
+        async with TestNatsBroker(broker, with_real=True) as br:
+            assert br._connection._inbox_prefix == "test"
+            assert "test" in str(br._connection.new_inbox)
+
+
     async def test_respect_middleware(self, queue):
         routes = []
 

--- a/tests/brokers/nats/test_test_client.py
+++ b/tests/brokers/nats/test_test_client.py
@@ -88,8 +88,8 @@ class TestTestclient(BrokerTestclientTestcase):
         broker = NatsBroker(inbox_prefix="test")
 
         async with TestNatsBroker(broker, with_real=True) as br:
-            assert br._connection._inbox_prefix == "test"
-            assert "test" in str(br._connection.new_inbox)
+            assert br._connection._inbox_prefix == b'test'
+            assert "test" in str(br._connection.new_inbox())
 
 
     async def test_respect_middleware(self, queue):

--- a/tests/brokers/nats/test_test_client.py
+++ b/tests/brokers/nats/test_test_client.py
@@ -88,7 +88,7 @@ class TestTestclient(BrokerTestclientTestcase):
         broker = NatsBroker(inbox_prefix="test")
 
         async with TestNatsBroker(broker, with_real=True) as br:
-            assert br._connection._inbox_prefix == b'test'
+            assert br._connection._inbox_prefix == b"test"
             assert "test" in str(br._connection.new_inbox())
 
 


### PR DESCRIPTION
# Description

Adds nuid from nats broker to generation unique ids.
Adds rpc_prefix, to allow support for nats streams inbox_. functionality via permissions, for consistency added the same rpc_prefix to the redis implementation. 


Fixes #1386 

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples, or any documentation updates)
- [X] New feature (a non-breaking change that adds functionality)

## Checklist

- [X] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [X] I have conducted a self-review of my own code
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
