### PR TITLE
feat: nats filter JS subscription support

### DIFF
--- a/faststream/nats/broker/registrator.py
+++ b/faststream/nats/broker/registrator.py
@@ -42,7 +42,7 @@ class NatsRegistrator(ABCBroker["Msg"]):
         subject: Annotated[
             str,
             Doc("NATS subject to subscribe."),
-        ],
+        ] = "",
         queue: Annotated[
             str,
             Doc(
@@ -209,7 +209,7 @@ class NatsRegistrator(ABCBroker["Msg"]):
 
         You can use it as a handler decorator `@broker.subscriber(...)`.
         """
-        if stream := self._stream_builder.create(stream):
+        if (stream := self._stream_builder.create(stream)) and subject:
             stream.add_subject(subject)
 
         subscriber = cast(
@@ -323,7 +323,7 @@ class NatsRegistrator(ABCBroker["Msg"]):
 
         Or you can create a publisher object to call it lately - `broker.publisher(...).publish(...)`.
         """
-        if stream := self._stream_builder.create(stream):
+        if (stream := self._stream_builder.create(stream)) and subject:
             stream.add_subject(subject)
 
         publisher = cast(

--- a/faststream/nats/subscriber/factory.py
+++ b/faststream/nats/subscriber/factory.py
@@ -80,6 +80,9 @@ def create_subscriber(
     if pull_sub is not None and stream is None:
         raise SetupError("Pull subscriber can be used only with a stream")
 
+    if not subject and not config:
+        raise SetupError("You must provide either `subject` or `config` option.")
+
     if stream:
         # TODO: pull & queue warning
         # TODO: push & durable warning

--- a/faststream/nats/subscriber/factory.py
+++ b/faststream/nats/subscriber/factory.py
@@ -4,6 +4,7 @@ from nats.aio.subscription import (
     DEFAULT_SUB_PENDING_BYTES_LIMIT,
     DEFAULT_SUB_PENDING_MSGS_LIMIT,
 )
+from nats.js.api import ConsumerConfig
 from nats.js.client import (
     DEFAULT_JS_SUB_PENDING_BYTES_LIMIT,
     DEFAULT_JS_SUB_PENDING_MSGS_LIMIT,
@@ -83,6 +84,8 @@ def create_subscriber(
     if not subject and not config:
         raise SetupError("You must provide either `subject` or `config` option.")
 
+    config = config or ConsumerConfig(filter_subjects=[])
+
     if stream:
         # TODO: pull & queue warning
         # TODO: push & durable warning
@@ -94,7 +97,6 @@ def create_subscriber(
             or DEFAULT_JS_SUB_PENDING_BYTES_LIMIT,
             "durable": durable,
             "stream": stream.name,
-            "config": config,
         }
 
         if pull_sub is not None:
@@ -123,6 +125,7 @@ def create_subscriber(
     if obj_watch is not None:
         return AsyncAPIObjStoreWatchSubscriber(
             subject=subject,
+            config=config,
             obj_watch=obj_watch,
             broker_dependencies=broker_dependencies,
             broker_middlewares=broker_middlewares,
@@ -134,6 +137,7 @@ def create_subscriber(
     if kv_watch is not None:
         return AsyncAPIKeyValueWatchSubscriber(
             subject=subject,
+            config=config,
             kv_watch=kv_watch,
             broker_dependencies=broker_dependencies,
             broker_middlewares=broker_middlewares,
@@ -147,6 +151,7 @@ def create_subscriber(
             return AsyncAPIConcurrentCoreSubscriber(
                 max_workers=max_workers,
                 subject=subject,
+                config=config,
                 queue=queue,
                 # basic args
                 extra_options=extra_options,
@@ -165,6 +170,7 @@ def create_subscriber(
         else:
             return AsyncAPICoreSubscriber(
                 subject=subject,
+                config=config,
                 queue=queue,
                 # basic args
                 extra_options=extra_options,
@@ -188,6 +194,7 @@ def create_subscriber(
                     pull_sub=pull_sub,
                     stream=stream,
                     subject=subject,
+                    config=config,
                     # basic args
                     extra_options=extra_options,
                     # Subscriber args
@@ -207,6 +214,7 @@ def create_subscriber(
                     max_workers=max_workers,
                     stream=stream,
                     subject=subject,
+                    config=config,
                     queue=queue,
                     # basic args
                     extra_options=extra_options,
@@ -229,6 +237,7 @@ def create_subscriber(
                         pull_sub=pull_sub,
                         stream=stream,
                         subject=subject,
+                        config=config,
                         # basic args
                         extra_options=extra_options,
                         # Subscriber args
@@ -248,6 +257,7 @@ def create_subscriber(
                         pull_sub=pull_sub,
                         stream=stream,
                         subject=subject,
+                        config=config,
                         # basic args
                         extra_options=extra_options,
                         # Subscriber args
@@ -267,6 +277,7 @@ def create_subscriber(
                     stream=stream,
                     subject=subject,
                     queue=queue,
+                    config=config,
                     # basic args
                     extra_options=extra_options,
                     # Subscriber args

--- a/faststream/nats/subscriber/usecase.py
+++ b/faststream/nats/subscriber/usecase.py
@@ -215,10 +215,12 @@ class LogicSubscriber(SubscriberUsecase[MsgType]):
                 for subject in (self.config.filter_subjects or ())
             ]
 
+    @cached_property
+    def _resolved_subject_string(self) -> str:
+        return self.subject or ", ".join(self.config.filter_subjects or ())
+
     def __hash__(self) -> int:
-        return self.get_routing_hash(
-            self.subject or "".join(self.config.filter_subjects or ())
-        )
+        return self.get_routing_hash(self._resolved_subject_string)
 
     @staticmethod
     def get_routing_hash(
@@ -558,7 +560,7 @@ class _StreamSubscriber(_DefaultSubscriber["Msg"]):
         """Log context factory using in `self.consume` scope."""
         return self.build_log_context(
             message=message,
-            subject=self.subject or ", ".join(self.config.filter_subjects or ()),
+            subject=self._resolved_subject_string,
             queue=self.queue,
             stream=self.stream.name,
         )

--- a/faststream/nats/subscriber/usecase.py
+++ b/faststream/nats/subscriber/usecase.py
@@ -20,7 +20,7 @@ from typing import (
 import anyio
 from fast_depends.dependencies import Depends
 from nats.errors import ConnectionClosedError, TimeoutError
-from nats.js.api import ObjectInfo
+from nats.js.api import ConsumerConfig, ObjectInfo
 from nats.js.kv import KeyValue
 from typing_extensions import Annotated, Doc, override
 
@@ -73,6 +73,7 @@ class LogicSubscriber(SubscriberUsecase[MsgType]):
         self,
         *,
         subject: str,
+        config: "ConsumerConfig",
         extra_options: Optional[AnyDict],
         # Subscriber args
         default_parser: "AsyncCallable",
@@ -88,6 +89,7 @@ class LogicSubscriber(SubscriberUsecase[MsgType]):
         include_in_schema: bool,
     ) -> None:
         self.subject = subject
+        self.config = config
 
         self.extra_options = extra_options or {}
 
@@ -205,10 +207,18 @@ class LogicSubscriber(SubscriberUsecase[MsgType]):
 
     def add_prefix(self, prefix: str) -> None:
         """Include Subscriber in router."""
-        self.subject = "".join((prefix, self.subject))
+        if self.subject:
+            self.subject = "".join((prefix, self.subject))
+        else:
+            self.config.filter_subjects = [
+                "".join((prefix, subject))
+                for subject in (self.config.filter_subjects or ())
+            ]
 
     def __hash__(self) -> int:
-        return self.get_routing_hash(self.subject)
+        return self.get_routing_hash(
+            self.subject or "".join(self.config.filter_subjects or ())
+        )
 
     @staticmethod
     def get_routing_hash(
@@ -229,6 +239,7 @@ class _DefaultSubscriber(LogicSubscriber[MsgType]):
         self,
         *,
         subject: str,
+        config: "ConsumerConfig",
         # default args
         extra_options: Optional[AnyDict],
         # Subscriber args
@@ -246,6 +257,7 @@ class _DefaultSubscriber(LogicSubscriber[MsgType]):
     ) -> None:
         super().__init__(
             subject=subject,
+            config=config,
             extra_options=extra_options,
             # subscriber args
             default_parser=default_parser,
@@ -368,6 +380,7 @@ class CoreSubscriber(_DefaultSubscriber["Msg"]):
         *,
         # default args
         subject: str,
+        config: "ConsumerConfig",
         queue: str,
         extra_options: Optional[AnyDict],
         # Subscriber args
@@ -387,6 +400,7 @@ class CoreSubscriber(_DefaultSubscriber["Msg"]):
 
         super().__init__(
             subject=subject,
+            config=config,
             extra_options=extra_options,
             # subscriber args
             default_parser=parser_.parse_message,
@@ -439,6 +453,7 @@ class ConcurrentCoreSubscriber(_ConcurrentMixin, CoreSubscriber):
         max_workers: int,
         # default args
         subject: str,
+        config: "ConsumerConfig",
         queue: str,
         extra_options: Optional[AnyDict],
         # Subscriber args
@@ -456,6 +471,7 @@ class ConcurrentCoreSubscriber(_ConcurrentMixin, CoreSubscriber):
             max_workers=max_workers,
             # basic args
             subject=subject,
+            config=config,
             queue=queue,
             extra_options=extra_options,
             # Propagated args
@@ -494,6 +510,7 @@ class _StreamSubscriber(_DefaultSubscriber["Msg"]):
         stream: "JStream",
         # default args
         subject: str,
+        config: "ConsumerConfig",
         queue: str,
         extra_options: Optional[AnyDict],
         # Subscriber args
@@ -514,6 +531,7 @@ class _StreamSubscriber(_DefaultSubscriber["Msg"]):
 
         super().__init__(
             subject=subject,
+            config=config,
             extra_options=extra_options,
             # subscriber args
             default_parser=parser_.parse_message,
@@ -540,7 +558,7 @@ class _StreamSubscriber(_DefaultSubscriber["Msg"]):
         """Log context factory using in `self.consume` scope."""
         return self.build_log_context(
             message=message,
-            subject=self.subject,
+            subject=self.subject or ", ".join(self.config.filter_subjects or ()),
             queue=self.queue,
             stream=self.stream.name,
         )
@@ -560,6 +578,7 @@ class PushStreamSubscription(_StreamSubscriber):
             subject=self.clear_subject,
             queue=self.queue,
             cb=self.consume,
+            config=self.config,
             **self.extra_options,
         )
 
@@ -574,6 +593,7 @@ class ConcurrentPushStreamSubscriber(_ConcurrentMixin, _StreamSubscriber):
         stream: "JStream",
         # default args
         subject: str,
+        config: "ConsumerConfig",
         queue: str,
         extra_options: Optional[AnyDict],
         # Subscriber args
@@ -592,6 +612,7 @@ class ConcurrentPushStreamSubscriber(_ConcurrentMixin, _StreamSubscriber):
             # basic args
             stream=stream,
             subject=subject,
+            config=config,
             queue=queue,
             extra_options=extra_options,
             # Propagated args
@@ -619,6 +640,7 @@ class ConcurrentPushStreamSubscriber(_ConcurrentMixin, _StreamSubscriber):
             subject=self.clear_subject,
             queue=self.queue,
             cb=self._put_msg,
+            config=self.config,
             **self.extra_options,
         )
 
@@ -633,6 +655,7 @@ class PullStreamSubscriber(_TasksMixin, _StreamSubscriber):
         stream: "JStream",
         # default args
         subject: str,
+        config: "ConsumerConfig",
         extra_options: Optional[AnyDict],
         # Subscriber args
         no_ack: bool,
@@ -651,6 +674,7 @@ class PullStreamSubscriber(_TasksMixin, _StreamSubscriber):
             # basic args
             stream=stream,
             subject=subject,
+            config=config,
             extra_options=extra_options,
             queue="",
             # Propagated args
@@ -708,6 +732,7 @@ class ConcurrentPullStreamSubscriber(_ConcurrentMixin, PullStreamSubscriber):
         pull_sub: "PullSub",
         stream: "JStream",
         subject: str,
+        config: "ConsumerConfig",
         extra_options: Optional[AnyDict],
         # Subscriber args
         no_ack: bool,
@@ -726,6 +751,7 @@ class ConcurrentPullStreamSubscriber(_ConcurrentMixin, PullStreamSubscriber):
             pull_sub=pull_sub,
             stream=stream,
             subject=subject,
+            config=config,
             extra_options=extra_options,
             # Propagated args
             no_ack=no_ack,
@@ -765,6 +791,7 @@ class BatchPullStreamSubscriber(_TasksMixin, _DefaultSubscriber[List["Msg"]]):
         *,
         # default args
         subject: str,
+        config: "ConsumerConfig",
         stream: "JStream",
         pull_sub: "PullSub",
         extra_options: Optional[AnyDict],
@@ -786,6 +813,7 @@ class BatchPullStreamSubscriber(_TasksMixin, _DefaultSubscriber[List["Msg"]]):
 
         super().__init__(
             subject=subject,
+            config=config,
             extra_options=extra_options,
             # subscriber args
             default_parser=parser.parse_batch,
@@ -837,6 +865,7 @@ class KeyValueWatchSubscriber(_TasksMixin, LogicSubscriber[KeyValue.Entry]):
         self,
         *,
         subject: str,
+        config: "ConsumerConfig",
         kv_watch: "KvWatch",
         broker_dependencies: Iterable[Depends],
         broker_middlewares: Iterable["BrokerMiddleware[KeyValue.Entry]"],
@@ -850,6 +879,7 @@ class KeyValueWatchSubscriber(_TasksMixin, LogicSubscriber[KeyValue.Entry]):
 
         super().__init__(
             subject=subject,
+            config=config,
             extra_options=None,
             no_ack=True,
             no_reply=True,
@@ -941,6 +971,7 @@ class ObjStoreWatchSubscriber(_TasksMixin, LogicSubscriber[ObjectInfo]):
         self,
         *,
         subject: str,
+        config: "ConsumerConfig",
         obj_watch: "ObjWatch",
         broker_dependencies: Iterable[Depends],
         broker_middlewares: Iterable["BrokerMiddleware[List[Msg]]"],
@@ -955,6 +986,7 @@ class ObjStoreWatchSubscriber(_TasksMixin, LogicSubscriber[ObjectInfo]):
 
         super().__init__(
             subject=subject,
+            config=config,
             extra_options=None,
             no_ack=True,
             no_reply=True,

--- a/faststream/nats/testing.py
+++ b/faststream/nats/testing.py
@@ -97,7 +97,10 @@ class FakeProducer(NatsFastProducer):
             ):
                 continue
 
-            if is_subject_match_wildcard(subject, handler.clear_subject):
+            if is_subject_match_wildcard(subject, handler.clear_subject) or any(
+                is_subject_match_wildcard(subject, filter_subject)
+                for filter_subject in (handler.config.filter_subjects or ())
+            ):
                 msg: Union[List[PatchedMessage], PatchedMessage]
                 if (pull := getattr(handler, "pull_sub", None)) and pull.batch:
                     msg = [incoming]

--- a/tests/brokers/nats/test_consume.py
+++ b/tests/brokers/nats/test_consume.py
@@ -60,7 +60,6 @@ class TestConsume(BrokerRealConsumeTestcase):
             await br.start()
             await asyncio.wait(
                 (
-                    asyncio.create_task(br.publish(1, f"{queue}.b")),
                     asyncio.create_task(br.publish(2, f"{queue}.a")),
                     asyncio.create_task(event.wait()),
                 ),

--- a/tests/brokers/nats/test_test_client.py
+++ b/tests/brokers/nats/test_test_client.py
@@ -4,7 +4,7 @@ import pytest
 
 from faststream import BaseMiddleware
 from faststream.exceptions import SetupError
-from faststream.nats import JStream, NatsBroker, PullSub, TestNatsBroker
+from faststream.nats import ConsumerConfig, JStream, NatsBroker, PullSub, TestNatsBroker
 from tests.brokers.base.testclient import BrokerTestclientTestcase
 
 
@@ -208,8 +208,6 @@ class TestTestclient(BrokerTestclientTestcase):
         self,
         queue: str,
         stream: JStream,
-        event: asyncio.Event,
-        mock,
     ):
         broker = self.get_broker()
 
@@ -219,9 +217,26 @@ class TestTestclient(BrokerTestclientTestcase):
             pull_sub=PullSub(1, batch=True),
         )
         def subscriber(m):
-            mock(m)
-            event.set()
+            pass
 
         async with TestNatsBroker(broker) as br:
             await br.publish("hello", queue)
             subscriber.mock.assert_called_once_with(["hello"])
+
+    async def test_consume_with_filter(
+        self,
+        queue,
+    ):
+        broker = self.get_broker()
+
+        @broker.subscriber(
+            config=ConsumerConfig(filter_subjects=[f"{queue}.a"]),
+            stream=JStream(queue, subjects=[f"{queue}.*"]),
+        )
+        def subscriber(m):
+            pass
+
+        async with TestNatsBroker(broker) as br:
+            await br.publish(1, f"{queue}.b")
+            await br.publish(2, f"{queue}.a")
+            subscriber.mock.assert_called_once_with(2)


### PR DESCRIPTION
# Description

Now **FastStream** has native interface for NATS JetStream subscription

```python
from faststream import FastStream, Logger
from faststream.nats import ConsumerConfig, JStream, NatsBroker

broker = NatsBroker()
app = FastStream(broker)

@broker.subscriber(
    config=ConsumerConfig(
        filter_subjects=["b.a", "b.b"],
    ),
    stream=JStream(
        "test-stream2",
        subjects=["b.*"],
    ),
)
async def handler(msg, logger: Logger):
    logger.info(msg)

@app.after_startup
async def test():
    await broker.publish(1, "b.a")
    await broker.publish(2, "b.b")
    await broker.publish(3, "b.c")  # will not be handled
```

Please include a summary of the change and specify which issue is being addressed. Additionally, provide relevant motivation and context.

Fixes #1518

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
