### PR TITLE
feat(multiprocess): restart child processes if they are not alive

### DIFF
--- a/faststream/cli/supervisors/multiprocess.py
+++ b/faststream/cli/supervisors/multiprocess.py
@@ -1,3 +1,4 @@
+import signal
 from typing import TYPE_CHECKING, Any, List, Tuple
 
 from faststream.cli.supervisors.basereload import BaseReload
@@ -17,8 +18,9 @@ class Multiprocess(BaseReload):
         target: "DecoratedCallable",
         args: Tuple[Any, ...],
         workers: int,
+        reload_delay: float = 0.5,
     ) -> None:
-        super().__init__(target, args, None)
+        super().__init__(target, args, reload_delay)
 
         self.workers = workers
         self.processes: List[SpawnProcess] = []
@@ -38,3 +40,32 @@ class Multiprocess(BaseReload):
             process.join()
 
         logger.info(f"Stopping parent process [{self.pid}]")
+
+    def restart(self) -> None:
+        active_processes = []
+
+        for process in self.processes:
+            if process.is_alive():
+                active_processes.append(process)
+                continue
+
+            pid = process.pid
+            exitcode = process.exitcode
+
+            log_msg = "Worker (pid:%s) exited with code %s."
+            if exitcode and abs(exitcode) == signal.SIGKILL:
+                log_msg += " Perhaps out of memory?"
+            logger.error(log_msg, pid, exitcode)
+
+            process.kill()
+
+            new_process = self._start_process()
+            logger.info(f"Started child process [{new_process.pid}]")
+            active_processes.append(new_process)
+
+        self.processes = active_processes
+
+    def should_restart(self) -> bool:
+        return next(
+            (True for process in self.processes if not process.is_alive()), False
+        )

--- a/faststream/cli/supervisors/multiprocess.py
+++ b/faststream/cli/supervisors/multiprocess.py
@@ -66,6 +66,4 @@ class Multiprocess(BaseReload):
         self.processes = active_processes
 
     def should_restart(self) -> bool:
-        return next(
-            (True for process in self.processes if not process.is_alive()), False
-        )
+        return not all(p.is_alive() for p in self.processes)


### PR DESCRIPTION
# Description

Restart child processes in MultiProcessor if the child process terminates for any reason. In our case a process was killed by oom-killer and the faststream app stopped processing events from Kafka.

Fixes # (issue number)

#1059 
## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [X] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [X] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [X] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [X] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [X] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
