### PR TITLE
Add allow_auto_create_topics to make automatic topic creation configurable

### DIFF
--- a/faststream/__about__.py
+++ b/faststream/__about__.py
@@ -1,6 +1,6 @@
 """Simple and fast framework to create message brokers based microservices."""
 
-__version__ = "0.5.13"
+__version__ = "0.5.14"
 
 SERVICE_NAME = f"faststream-{__version__}"
 

--- a/faststream/confluent/broker/broker.py
+++ b/faststream/confluent/broker/broker.py
@@ -124,6 +124,12 @@ class KafkaBroker(
             """
             ),
         ] = SERVICE_NAME,
+        allow_auto_create_topics: Annotated[
+            bool,
+            Doc("""
+            Allow automatic topic creation on the broker when subscribing to or assigning non-existent topics.
+            """),
+        ] = True,
         config: Annotated[
             Optional[ConfluentConfig],
             Doc("""
@@ -350,6 +356,7 @@ class KafkaBroker(
             request_timeout_ms=request_timeout_ms,
             retry_backoff_ms=retry_backoff_ms,
             metadata_max_age_ms=metadata_max_age_ms,
+            allow_auto_create_topics=allow_auto_create_topics,
             connections_max_idle_ms=connections_max_idle_ms,
             loop=loop,
             # publisher args

--- a/faststream/confluent/client.py
+++ b/faststream/confluent/client.py
@@ -97,6 +97,7 @@ class AsyncConfluentProducer:
         enable_idempotence: bool = False,
         transactional_id: Optional[Union[str, int]] = None,
         transaction_timeout_ms: int = 60000,
+        allow_auto_create_topics: bool = True,
         sasl_mechanism: Optional[str] = None,
         sasl_plain_password: Optional[str] = None,
         sasl_plain_username: Optional[str] = None,
@@ -138,6 +139,7 @@ class AsyncConfluentProducer:
             "retry.backoff.ms": retry_backoff_ms,
             "security.protocol": security_protocol.lower(),
             "connections.max.idle.ms": connections_max_idle_ms,
+            "allow.auto.create.topics": allow_auto_create_topics,
         }
         self.config = {**self.config, **config_from_params}
 
@@ -223,6 +225,7 @@ class TopicPartition(NamedTuple):
 def create_topics(
     topics: List[str],
     config: Dict[str, Optional[Union[str, int, float, bool, Any]]],
+    logger: Union["LoggerProto", None, object] = logger,
 ) -> None:
     """Creates Kafka topics using the provided configuration."""
     required_config_params = (
@@ -252,9 +255,9 @@ def create_topics(
             f.result()  # The result itself is None
         except Exception as e:  # noqa: PERF203
             if "TOPIC_ALREADY_EXISTS" not in str(e):
-                logger.warning(f"Failed to create topic {topic}: {e}")
+                logger.warning(f"Failed to create topic {topic}: {e}")  # type: ignore[union-attr]
         else:
-            logger.info(f"Topic `{topic}` created.")
+            logger.info(f"Topic `{topic}` created.")  # type: ignore[union-attr]
 
 
 class AsyncConfluentConsumer:
@@ -285,6 +288,7 @@ class AsyncConfluentConsumer:
         security_protocol: str = "PLAINTEXT",
         connections_max_idle_ms: int = 540000,
         isolation_level: str = "read_uncommitted",
+        allow_auto_create_topics: bool = True,
         sasl_mechanism: Optional[str] = None,
         sasl_plain_password: Optional[str] = None,
         sasl_plain_username: Optional[str] = None,
@@ -316,7 +320,7 @@ class AsyncConfluentConsumer:
                 ]
             )
         config_from_params = {
-            "allow.auto.create.topics": True,
+            "allow.auto.create.topics": allow_auto_create_topics,
             # "topic.metadata.refresh.interval.ms": 1000,
             "bootstrap.servers": bootstrap_servers,
             "client.id": client_id,
@@ -354,7 +358,12 @@ class AsyncConfluentConsumer:
 
         self.loop = loop or asyncio.get_event_loop()
 
-        create_topics(topics=self.topics, config=self.config)
+        if allow_auto_create_topics:
+            create_topics(topics=self.topics, config=self.config, logger=logger)
+        else:
+            logger.warning(  # type: ignore[union-attr]
+                "Auto create topics is disabled. Make sure the topics exist."
+            )
         self.consumer = Consumer(self.config, logger=self.logger)
 
     async def start(self) -> None:

--- a/faststream/confluent/client.py
+++ b/faststream/confluent/client.py
@@ -154,8 +154,8 @@ class AsyncConfluentProducer:
 
         self.producer = Producer(self.config, logger=self.logger)
         # self.producer.init_transactions()
-        self.producer.list_topics()
         self.loop = loop or asyncio.get_event_loop()
+        self.loop.run_in_executor(None, self.producer.list_topics)
 
     async def stop(self) -> None:
         """Stop the Kafka producer and flush remaining messages."""
@@ -359,7 +359,9 @@ class AsyncConfluentConsumer:
         self.loop = loop or asyncio.get_event_loop()
 
         if allow_auto_create_topics:
-            create_topics(topics=self.topics, config=self.config, logger=logger)
+            self.loop.run_in_executor(
+                None, create_topics, self.topics, self.config, logger
+            )
         else:
             logger.warning(  # type: ignore[union-attr]
                 "Auto create topics is disabled. Make sure the topics exist."

--- a/faststream/confluent/schemas/params.py
+++ b/faststream/confluent/schemas/params.py
@@ -17,6 +17,7 @@ class ConsumerConnectionParams(TypedDict, total=False):
         "PLAINTEXT",
     ]
     connections_max_idle_ms: int
+    allow_auto_create_topics: bool
     sasl_mechanism: Literal[
         "PLAIN",
         "GSSAPI",


### PR DESCRIPTION
# Description

We used to always create topics automatically and provided no way to make it configurable. This PR introduces a new variable called `allow_auto_create_topics` to make automatic topic creation configurable.
I have included a warning when `allow_auto_create_topics` is set to `False` because `confluent-kafka-python` backfires/crumbles terribly if it tries to access an non existent topic as mentioned here - https://github.com/confluentinc/confluent-kafka-python/issues/1547.
There were few blocking calls in the `__init__` method of Async Confluent Producer and Consumer. I have used `run_in_executor` to make them non-blocking.

Fixes #1486, #1363

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [x] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
