### PR TITLE
fix: correct single dataclass argument AsyncAPI payload generation

### DIFF
--- a/faststream/asyncapi/message.py
+++ b/faststream/asyncapi/message.py
@@ -112,7 +112,7 @@ def get_model_schema(
         param_body = param_body[name]
 
         if defs := body.get(DEF_KEY):
-            # single argument with useless refference
+            # single argument with useless reference
             if param_body.get("$ref"):
                 ref_obj: Dict[str, Any] = next(iter(defs.values()))
                 return ref_obj

--- a/faststream/asyncapi/message.py
+++ b/faststream/asyncapi/message.py
@@ -112,7 +112,10 @@ def get_model_schema(
         param_body = param_body[name]
 
         if defs := body.get(DEF_KEY):
-            param_body[DEF_KEY] = defs
+            if param_body.get("$ref"):
+                return next(iter(defs.values()))
+            else:
+                param_body[DEF_KEY] = defs
 
         original_title = param.title if PYDANTIC_V2 else param.field_info.title  # type: ignore[attr-defined]
 

--- a/faststream/asyncapi/message.py
+++ b/faststream/asyncapi/message.py
@@ -112,8 +112,10 @@ def get_model_schema(
         param_body = param_body[name]
 
         if defs := body.get(DEF_KEY):
+            # single argument with useless refference
             if param_body.get("$ref"):
-                return next(iter(defs.values()))
+                ref_obj: Dict[str, Any] = next(iter(defs.values()))
+                return ref_obj
             else:
                 param_body[DEF_KEY] = defs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ devdocs = [
     "mkdocstrings[python]==0.25.1",
     "mkdocs-literate-nav==0.6.1",
     "mkdocs-git-revision-date-localized-plugin==1.2.6",
-    "mike==2.1.1",                                      # versioning
+    "mike==2.1.2",                                      # versioning
     "mkdocs-minify-plugin==0.8.0",
     "mkdocs-macros-plugin==1.0.5",                      # includes with variables
     "mkdocs-glightbox==0.4.0",                          # img zoom
@@ -97,7 +97,7 @@ devdocs = [
 
 types = [
     "faststream[optionals]",
-    "mypy==1.10.0",
+    "mypy==1.10.1",
     # mypy extensions
     "types-Deprecated",
     "types-PyYAML",
@@ -113,7 +113,7 @@ lint = [
     "faststream[types]",
     "ruff==0.5.1",
     "bandit==1.7.9",
-    "semgrep==1.78.0",
+    "semgrep==1.79.0",
     "codespell==2.3.0",
 ]
 

--- a/tests/asyncapi/base/arguments.py
+++ b/tests/asyncapi/base/arguments.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from enum import Enum
 from typing import Optional, Type, Union
 
@@ -212,6 +213,33 @@ class FastAPICompatible:
                     "msg": {"title": "Msg", "type": "string"},
                 },
                 "required": ["msg"],
+                "title": key,
+                "type": "object",
+            }
+
+    def test_dataclass(self):
+        @dataclass
+        class User:
+            id: int
+            name: str = ""
+
+        broker = self.broker_class()
+
+        @broker.subscriber("test")
+        async def handle(user: User): ...
+
+        schema = get_app_schema(self.build_app(broker)).to_jsonable()
+
+        payload = schema["components"]["schemas"]
+
+        for key, v in payload.items():
+            assert key == "User"
+            assert v == {
+                "properties": {
+                    "id": {"title": "Id", "type": "integer"},
+                    "name": {"default": "", "title": "Name", "type": "string"},
+                },
+                "required": ["id"],
                 "title": key,
                 "type": "object",
             }


### PR DESCRIPTION
# Description

Correct AsyncAPI payload schema generation in the following case:

```python
from dataclasses import dataclass

@dataclass
class IncomingDTO:
   data: str

@broker.subscriber(...)
async def handler(body: IncomingDTO): ...
```

Previosly, useless additional model with just a reference was generating

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [x] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
