### PR TITLE
Added additional parameters to HandlerException

### DIFF
--- a/faststream/broker/acknowledgement_watcher.py
+++ b/faststream/broker/acknowledgement_watcher.py
@@ -154,10 +154,7 @@ class WatcherContext:
                 await self.__ack(**exc_val.extra_options)
 
             elif isinstance(exc_val, NackMessage):
-                if self.watcher.is_max(self.message.message_id):
-                    await self.__reject()
-                else:
-                    await self.__nack(**exc_val.extra_options)
+                await self.__nack(**exc_val.extra_options)
 
             elif isinstance(exc_val, RejectMessage):  # pragma: no branch
                 await self.__reject(**exc_val.extra_options)

--- a/faststream/broker/acknowledgement_watcher.py
+++ b/faststream/broker/acknowledgement_watcher.py
@@ -151,16 +151,16 @@ class WatcherContext:
                 self.watcher.remove(self.message.message_id)
 
             elif isinstance(exc_val, AckMessage):
-                await self.__ack()
+                await self.__ack(**exc_val.extra_options)
 
             elif isinstance(exc_val, NackMessage):
                 if self.watcher.is_max(self.message.message_id):
                     await self.__reject()
                 else:
-                    await self.__nack()
+                    await self.__nack(**exc_val.extra_options)
 
             elif isinstance(exc_val, RejectMessage):  # pragma: no branch
-                await self.__reject()
+                await self.__reject(**exc_val.extra_options)
 
             # Exception was processed and suppressed
             return True
@@ -174,25 +174,25 @@ class WatcherContext:
         # Exception was not processed
         return False
 
-    async def __ack(self) -> None:
+    async def __ack(self, **exc_extra_options: Any) -> None:
         try:
-            await self.message.ack(**self.extra_options)
+            await self.message.ack(**self.extra_options, **exc_extra_options)
         except Exception as er:
             if self.logger is not None:
                 self.logger.log(logging.ERROR, er, exc_info=er)
         else:
             self.watcher.remove(self.message.message_id)
 
-    async def __nack(self) -> None:
+    async def __nack(self, **exc_extra_options: Any) -> None:
         try:
-            await self.message.nack(**self.extra_options)
+            await self.message.nack(**self.extra_options, **exc_extra_options)
         except Exception as er:
             if self.logger is not None:
                 self.logger.log(logging.ERROR, er, exc_info=er)
 
-    async def __reject(self) -> None:
+    async def __reject(self, **exc_extra_options: Any) -> None:
         try:
-            await self.message.reject(**self.extra_options)
+            await self.message.reject(**self.extra_options, **exc_extra_options)
         except Exception as er:
             if self.logger is not None:
                 self.logger.log(logging.ERROR, er, exc_info=er)

--- a/faststream/exceptions.py
+++ b/faststream/exceptions.py
@@ -28,16 +28,6 @@ class StopApplication(IgnoredException, SystemExit):
 class HandlerException(IgnoredException):
     """Base Handler Exception."""
 
-    def __init__(self, **kwargs: Annotated[
-        Any,
-        Doc(
-            "Additional parameters that will be "
-            "passed to message ack method call"
-        )
-    ]):
-        self.extra_options = kwargs
-        super().__init__()
-
 
 class SkipMessage(HandlerException):
     """Watcher Instruction to skip message."""
@@ -47,21 +37,57 @@ class SkipMessage(HandlerException):
 
 
 class AckMessage(HandlerException):
-    """Raise it to `ack` a message immediately."""
+    """Exception raised to acknowledge a message immediately.
+
+    This exception can be used to ack a message with additional options.
+    To watch all allowed parameters, please take a look at your broker `message.ack(**extra_options)` method
+    signature.
+
+    Args:
+        extra_options (Any): Additional parameters that will be passed to `message.ack(**extra_options)` method.
+    """
+
+    def __init__(self, **extra_options: Any):
+        self.extra_options = extra_options
+        super().__init__()
 
     def __str__(self) -> str:
         return "Message was acked"
 
 
 class NackMessage(HandlerException):
-    """Raise it to `nack` a message immediately."""
+    """Exception raised to negatively acknowledge a message immediately.
+
+    This exception can be used to nack a message with additional options.
+    To watch all allowed parameters, please take a look to your broker's `message.nack(**extra_options)` method
+    signature.
+
+    Args:
+        extra_options (Any): Additional parameters that will be passed to `message.nack(**extra_options)` method.
+    """
+
+    def __init__(self, **kwargs: Any):
+        self.extra_options = kwargs
+        super().__init__()
 
     def __str__(self) -> str:
         return "Message was nacked"
 
 
 class RejectMessage(HandlerException):
-    """Raise it to `reject` a message immediately."""
+    """Exception raised to reject a message immediately.
+
+    This exception can be used to reject a message with additional options.
+    To watch all allowed parameters, please take a look to your broker's `message.reject(**extra_options)` method
+    signature.
+
+    Args:
+        extra_options (Any): Additional parameters that will be passed to `message.reject(**extra_options)` method.
+    """
+
+    def __init__(self, **kwargs: Any):
+        self.extra_options = kwargs
+        super().__init__()
 
     def __str__(self) -> str:
         return "Message was rejected"

--- a/faststream/exceptions.py
+++ b/faststream/exceptions.py
@@ -1,6 +1,6 @@
-from typing import Annotated, Any, Iterable
+from typing import Any, Iterable
 
-from typing_extensions import Doc
+from typing_extensions import Annotated, Doc
 
 
 class FastStreamException(Exception):  # noqa: N818

--- a/faststream/exceptions.py
+++ b/faststream/exceptions.py
@@ -1,7 +1,5 @@
 from typing import Any, Iterable
 
-from typing_extensions import Annotated, Doc
-
 
 class FastStreamException(Exception):  # noqa: N818
     """Basic FastStream exception class."""

--- a/faststream/exceptions.py
+++ b/faststream/exceptions.py
@@ -1,4 +1,5 @@
-from typing import Iterable
+from typing import Any, Iterable, Annotated
+from typing_extensions import Doc
 
 
 class FastStreamException(Exception):  # noqa: N818
@@ -25,6 +26,16 @@ class StopApplication(IgnoredException, SystemExit):
 
 class HandlerException(IgnoredException):
     """Base Handler Exception."""
+
+    def __init__(self, **kwargs: Annotated[
+        Any,
+        Doc(
+            "Additional parameters that will be "
+            "passed to message ack method call"
+        )
+    ]):
+        self.extra_options = kwargs
+        super().__init__()
 
 
 class SkipMessage(HandlerException):

--- a/faststream/exceptions.py
+++ b/faststream/exceptions.py
@@ -1,4 +1,5 @@
-from typing import Any, Iterable, Annotated
+from typing import Annotated, Any, Iterable
+
 from typing_extensions import Doc
 
 

--- a/tests/brokers/test_pushback.py
+++ b/tests/brokers/test_pushback.py
@@ -125,3 +125,18 @@ async def test_ignore_skip(async_mock: AsyncMock, message):
     assert not message.nack.called
     assert not message.reject.called
     assert not message.ack.called
+
+
+@pytest.mark.asyncio()
+async def test_additional_params_with_handler_exception(async_mock: AsyncMock, message):
+    watcher = EndlessWatcher()
+
+    context = WatcherContext(
+        message=message,
+        watcher=watcher,
+    )
+
+    async with context:
+        raise NackMessage(delay=5)
+
+    message.nack.assert_called_with(delay=5)

--- a/tests/brokers/test_pushback.py
+++ b/tests/brokers/test_pushback.py
@@ -70,26 +70,6 @@ async def test_push_back_watcher(async_mock: AsyncMock, message):
 
 
 @pytest.mark.asyncio()
-async def test_push_back_watcher_with_nack_exception(async_mock: AsyncMock, message):
-    watcher = CounterWatcher(3)
-
-    context = WatcherContext(
-        message=message,
-        watcher=watcher,
-    )
-
-    async_mock.side_effect = NackMessage()
-
-    while not message.reject.called and message.nack.await_count < 5:
-        async with context:
-            await async_mock()
-
-    assert not message.ack.await_count
-    assert message.nack.await_count == 3
-    message.reject.assert_awaited_once()
-
-
-@pytest.mark.asyncio()
 async def test_push_endless_back_watcher(async_mock: AsyncMock, message):
     watcher = EndlessWatcher()
 


### PR DESCRIPTION
# Description

The HandlerException class has been enhanced with additional parameters, which are now passed to the `message.ack`, `message.nack`, and `message.reject` methods within the `WatcherContext`. This update allows the use of `raise NackMessage(delay=5)` instead of `return message.nack(delay=5)`.

Fixed the logic in `WatcherContext`, where if a user explicitly raises `NackMessage` with `retry=False`, the context now calls `message.nack()` instead of `message.reject()`.

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples, or any documentation updates)
- [x] Bug fix (a non-breaking change that resolves an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications