### PR TITLE
Add `__call__` method to `BaseMiddleware`

### DIFF
--- a/faststream/broker/middlewares/base.py
+++ b/faststream/broker/middlewares/base.py
@@ -15,6 +15,11 @@ class BaseMiddleware:
     def __init__(self, msg: Optional[Any] = None) -> None:
         self.msg = msg
 
+    def __call__(self, msg: Optional[Any]) -> Self:
+        """Call the object with a message."""
+        self.msg = msg
+        return self
+
     async def on_receive(self) -> None:
         """Hook to call on message receive."""
         pass


### PR DESCRIPTION
# Description

I added the `__call__` method to `BaseMiddleware` so that I don't have to define this method in each middleware.

Fixes # (issue number)

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [x] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [ ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
