### PR TITLE
Bug: resolve missing seek on kafka fakeconsumer

### DIFF
--- a/faststream/kafka/message.py
+++ b/faststream/kafka/message.py
@@ -20,6 +20,9 @@ class FakeConsumer:
     async def commit(self) -> None:
         pass
 
+    def seek(self, **kwargs: Any) -> None:
+        pass
+
 
 FAKE_CONSUMER = FakeConsumer()
 
@@ -54,10 +57,12 @@ class KafkaMessage(
                 self.raw_message.topic,  # type: ignore[union-attr]
                 self.raw_message.partition,  # type: ignore[union-attr]
             )
+
             self.consumer.seek(  # type: ignore[attr-defined]
                 partition=topic_partition,
                 offset=self.raw_message.offset,  # type: ignore[union-attr]
             )
+
             await super().nack()
 
 


### PR DESCRIPTION
# Description

With the recent changes in `0.5.18`, if a message raises a NackMessage or calls `msg.nack()` while in test mode, 
an exception will be throw due to `seek` not existing on the FakeConsumer.

```

    async def nack(self) -> None:
        """Reject the Kafka message."""
        if not self.committed:
            topic_partition = AIOKafkaTopicPartition(
                self.raw_message.topic,  # type: ignore[union-attr]
                self.raw_message.partition,  # type: ignore[union-attr]
            )
>           self.consumer.seek(  # type: ignore[attr-defined]
                partition=topic_partition,
                offset=self.raw_message.offset,  # type: ignore[union-attr]
            )
E           AttributeError: 'FakeConsumer' object has no attribute 'seek'

.venv/lib/python3.12/site-packages/faststream/kafka/message.py:58: AttributeError

```


## Type of change

- [x ] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [x] I have included code examples to illustrate the modifications
