### PR TITLE
Skip building docs in pre-commit CI job

### DIFF
--- a/.github/workflows/pr_tests.yaml
+++ b/.github/workflows/pr_tests.yaml
@@ -21,6 +21,8 @@ jobs:
   pre-commit-check:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    env:
+      SKIP: "docs"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
# Description

We already have a CI Job which runs build docs script for PRs and automatically updates the API docs in the same PR - https://github.com/airtai/faststream/blob/main/.github/workflows/docs_update-references.yaml. 
So, no need to run build docs as part of pre-commit.

Fixes #1703 

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [x] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [ ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
