### PR TITLE
Fix multiple docs issues

### DIFF
--- a/.github/workflows/docs_check-broken-links.yaml
+++ b/.github/workflows/docs_check-broken-links.yaml
@@ -17,5 +17,5 @@ jobs:
         uses: ruzickap/action-my-broken-link-checker@v2
         with:
           url: https://faststream.airt.ai
-          cmd_params: '--buffer-size=8192 --max-connections=1 --color=always --header="User-Agent:Mozilla/5.0(Firefox/97.0)" --exclude="(localhost:8000|linkedin.com|fonts.gstatic.com|reddit.com)" --max-connections-per-host=1 --rate-limit=1'
+          cmd_params: '--buffer-size=8192 --max-connections=1 --color=always --header="User-Agent:Mozilla/5.0(Firefox/97.0)" --exclude="(localhost:8000|linkedin.com|fonts.gstatic.com|reddit.com)" --max-connections-per-host=1 --rate-limit=1 --max-response-body-size=20000000'
           debug: true

--- a/.github/workflows/docs_deploy.yaml
+++ b/.github/workflows/docs_deploy.yaml
@@ -6,7 +6,7 @@ on:
       - main
     paths:
       - docs/**
-      - .github/workflows/deploy-docs.yaml
+      - .github/workflows/docs_deploy.yaml
       - faststream/__about__.py
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@
 
   <br/>
 
-  <a href="https://github.com/airtai/faststream/actions/workflows/pr_codeql.yml" target="_blank">
-    <img src="https://github.com/airtai/faststream/actions/workflows/pr_codeql.yml/badge.svg" alt="CodeQL">
+  <a href="https://github.com/airtai/faststream/actions/workflows/pr_codeql.yaml" target="_blank">
+    <img src="https://github.com/airtai/faststream/actions/workflows/pr_codeql.yaml/badge.svg" alt="CodeQL">
   </a>
 
   <a href="https://github.com/airtai/faststream/actions/workflows/pr_dependency-review.yaml" target="_blank">

--- a/README.md
+++ b/README.md
@@ -73,8 +73,6 @@ Making streaming microservices has never been easier. Designed with junior devel
 
 - [**Integrations**](#any-framework): **FastStream** is fully compatible with any HTTP framework you want ([**FastAPI**](#fastapi-plugin) especially)
 
-- [**Built for Automatic Code Generation**](#code-generator): **FastStream** is optimized for automatic code generation using advanced models like GPT and Llama
-
 That's **FastStream** in a nutshell—easy, efficient, and powerful. Whether you're just starting with streaming microservices or looking to scale, **FastStream** has got you covered.
 
 ---

--- a/docs/create_api_docs.py
+++ b/docs/create_api_docs.py
@@ -310,7 +310,7 @@ def _generate_api_docs_for_module(root_path: Path, module_name: str) -> Tuple[st
     src = """                    - [ContactDict](api/faststream/asyncapi/schema/info/ContactDict.md)
 """
     dst = """                    - [ContactDict](api/faststream/asyncapi/schema/info/ContactDict.md)
-                    - [EmailStr](api/faststream/asyncapi/schema/info/EmailStr.md)
+                        - [EmailStr](api/faststream/asyncapi/schema/info/EmailStr.md)
 """
     api_summary = api_summary.replace(src, dst)
 

--- a/docs/create_api_docs.py
+++ b/docs/create_api_docs.py
@@ -342,6 +342,12 @@ def create_api_docs(
     (docs_dir / "SUMMARY.md").write_text(summary)
 
 
+def on_page_markdown(markdown, *, page, config, files):
+    """Mkdocs hook to update the edit URL for the public API pages."""
+    if "public_api" in page.edit_url:
+        page.edit_url = page.edit_url.replace("public_api", "api")
+
+
 if __name__ == "__main__":
     root = Path(__file__).resolve().parent
     create_api_docs(root, "faststream")

--- a/docs/docs/SUMMARY.md
+++ b/docs/docs/SUMMARY.md
@@ -306,7 +306,7 @@ search:
                     - info
                         - [Contact](api/faststream/asyncapi/schema/info/Contact.md)
                         - [ContactDict](api/faststream/asyncapi/schema/info/ContactDict.md)
-                    - [EmailStr](api/faststream/asyncapi/schema/info/EmailStr.md)
+                        - [EmailStr](api/faststream/asyncapi/schema/info/EmailStr.md)
                         - [Info](api/faststream/asyncapi/schema/info/Info.md)
                         - [License](api/faststream/asyncapi/schema/info/License.md)
                         - [LicenseDict](api/faststream/asyncapi/schema/info/LicenseDict.md)

--- a/docs/docs/en/faststream.md
+++ b/docs/docs/en/faststream.md
@@ -80,8 +80,6 @@ Making streaming microservices has never been easier. Designed with junior devel
 
 - [**Integrations**](#any-framework): **FastStream** is fully compatible with any HTTP framework you want ([**FastAPI**](#fastapi-plugin) especially)
 
-- [**Built for Automatic Code Generation**](#code-generator): **FastStream** is optimized for automatic code generation using advanced models like GPT and Llama
-
 That's **FastStream** in a nutshell—easy, efficient, and powerful. Whether you're just starting with streaming microservices or looking to scale, **FastStream** has got you covered.
 
 ---

--- a/docs/docs/en/faststream.md
+++ b/docs/docs/en/faststream.md
@@ -34,8 +34,8 @@ search:
 
   <br/>
 
-  <a href="https://github.com/airtai/faststream/actions/workflows/pr_codeql.yml" target="_blank">
-    <img src="https://github.com/airtai/faststream/actions/workflows/pr_codeql.yml/badge.svg" alt="CodeQL">
+  <a href="https://github.com/airtai/faststream/actions/workflows/pr_codeql.yaml" target="_blank">
+    <img src="https://github.com/airtai/faststream/actions/workflows/pr_codeql.yaml/badge.svg" alt="CodeQL">
   </a>
 
   <a href="https://github.com/airtai/faststream/actions/workflows/pr_dependency-review.yaml" target="_blank">

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -132,6 +132,9 @@ plugins:
       redirect_template: templates/redirect.html
       canonical_version: latest
 
+hooks:
+  - create_api_docs.py
+
 markdown_extensions:
   - toc:
       permalink: "#"             # replace TOC block symbol

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -166,7 +166,7 @@ extra:
     - icon: fontawesome/brands/github-alt
       link: https://github.com/airtai/faststream
     - icon: fontawesome/brands/twitter
-      link: https://twitter.com/airt_AI
+      link: https://x.com/airt_AI
     - icon: fontawesome/brands/facebook
       link: https://www.facebook.com/airt.ai.api/
     - icon: fontawesome/brands/linkedin

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -620,7 +620,7 @@
    <div class="container tx-container">
       <div class="row">
          <div class="col col--4 testimonialWrapper_gvoa">
-            <a href="https://twitter.com/nats_io/status/1716460663734759831" target="_blank" rel="noopener noreferrer"
+            <a href="https://x.com/nats_io/status/1716460663734759831" target="_blank" rel="noopener noreferrer"
                class="testimonialAnchor_iYyG">
                <div>
                   <div class="testimonialHeader_iSI8">
@@ -826,7 +826,7 @@
                   </div>
                </div>
             </a>
-            <a href="https://twitter.com/edwardkens50830/status/1710248156540145979" target="_blank"
+            <a href="https://x.com/edwardkens50830/status/1710248156540145979" target="_blank"
                rel="noopener noreferrer" class="testimonialAnchor_iYyG">
                <div>
                   <div class="testimonialHeader_iSI8">
@@ -864,7 +864,7 @@
                   </div>
                </div>
             </a>
-            <a href="https://twitter.com/dev_raj4522/status/1706417606956343529" target="_blank"
+            <a href="https://x.com/dev_raj4522/status/1706417606956343529" target="_blank"
                rel="noopener noreferrer" class="testimonialAnchor_iYyG hidden">
                <div>
                   <div class="testimonialHeader_iSI8">


### PR DESCRIPTION
# Description

- [x] As mentioned in issue https://github.com/airtai/faststream/issues/1684#issue-2464742759, the edit button in `public_api` points to a wrong url in github. This is because `public_api` is a symlink to `api` directory and github does not do automatic redirection for symlinks. To fix this, I have used [mkdocs hooks](https://www.mkdocs.org/user-guide/configuration/#hooks) feature, and wrote a new hook function `on_page_markdown` in `create_api_docs.py`.
- [x] Fix broken codeql svg badge
- [x] Update `--max-response-body-size` to prevent failures in check docs links workflow
- [x] Fix wrong path in `docs_deploy.yaml`
- [x] Remove a mention of faststream-gen
- [x] Fix formatting of `EmailStr` in api summary
- [x] Rename twitter.com to x.com to prevent redirection which consumes bit more time in CI

Fixes #1684, #1438

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [ ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
