### PR TITLE
CI: group Dependabot updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,29 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "devcontainers"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
       interval: weekly
+    # https://til.simonwillison.net/github/dependabot-python-setup
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: devcontainers
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
# Description

Currently Dependabot creates a new PR for each dependency it updates:
![изображение](https://github.com/user-attachments/assets/2ea85f28-c3db-4b05-8d7e-45e1d2f4a9c4)

My proposal is to create one PR for each dependency *type* (pip, github-actions, devcontainers), containing all the updates since previous week:
![изображение](https://github.com/user-attachments/assets/8f729de2-aa00-45ef-a431-908ff1260c07)

Here is an example:
https://github.com/MobileTeleSystems/horizon/blob/8b21b805254d1d0b118660f973d2f177e5368201/.github/dependabot.yml#L22-L26
https://github.com/MobileTeleSystems/horizon/pull/75
![изображение](https://github.com/user-attachments/assets/9e4dfee9-d3a2-4dc2-bbab-501d2ab649d4)


## Type of change

Please delete options that are not relevant.

- [x] CI

## Checklist

- [ ] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
