### PR TITLE
Fix Dependabot group names

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
     schedule:
       interval: weekly
     groups:
-      github-actions:
+      pip:
         patterns:
           - "*"
 
@@ -24,6 +24,6 @@ updates:
     schedule:
       interval: weekly
     groups:
-      github-actions:
+      devcontainers:
         patterns:
           - "*"


### PR DESCRIPTION
# Description

#1719 introduced grouping Dependabot PRs, but PR for different integration types were conbined to one group named `github-actions`.

Instead make different groups for different integration types.

## Type of change

Please delete options that are not relevant.

- [X] CI

## Checklist

- [ ] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [X] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
