### PR TITLE
Uninstall email-validator to generate docs page for EmailStr

### DIFF
--- a/.github/workflows/docs_deploy.yaml
+++ b/.github/workflows/docs_deploy.yaml
@@ -30,6 +30,7 @@ jobs:
           set -ux
           python -m pip install uv
           uv pip install --system -e .[dev]
+          uv pip uninstall --system email-validator # This is to fix broken link in docs
       - run: ./scripts/build-docs.sh
       - run: echo "VERSION=$(python3 -c 'from importlib.metadata import version; print(".".join(version("faststream").split(".")[:2]))')" >> $GITHUB_ENV
       - run: echo "IS_RC=$(python3 -c 'from importlib.metadata import version; print("rc" in version("faststream"))')" >> $GITHUB_ENV

--- a/docs/docs/en/api/faststream/asyncapi/schema/info/EmailStr.md
+++ b/docs/docs/en/api/faststream/asyncapi/schema/info/EmailStr.md
@@ -1,0 +1,11 @@
+---
+# 0.5 - API
+# 2 - Release
+# 3 - Contributing
+# 5 - Template Page
+# 10 - Default
+search:
+  boost: 0.5
+---
+
+::: faststream.asyncapi.schema.info.EmailStr


### PR DESCRIPTION
# Description

If we have `email-validator` installed then `EmailStr` will not be declared - https://github.com/airtai/faststream/blob/main/faststream/asyncapi/schema/info.py#L25. This results in a broken link which points to `EmailStr` in docs - https://github.com/airtai/faststream/actions/runs/10630908843/job/29470753617

Fixes # (issue number)

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [ ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
