### PR TITLE
build(#1430): separate cli faststream to its own distribution

### DIFF
--- a/docs/docs/SUMMARY.md
+++ b/docs/docs/SUMMARY.md
@@ -41,7 +41,7 @@ search:
         - [HTTP Async Frameworks](getting-started/integrations/frameworks/index.md)
         - [FastAPI Plugin](getting-started/integrations/fastapi/index.md)
         - [Django](getting-started/integrations/django/index.md)
-    - [CLI commands](getting-started/cli/index.md)
+    - [CLI](getting-started/cli/index.md)
     - [ASGI](getting-started/asgi.md)
     - [OpenTelemetry](getting-started/opentelemetry/index.md)
     - [Logging](getting-started/logging.md)

--- a/docs/docs/en/getting-started/cli/index.md
+++ b/docs/docs/en/getting-started/cli/index.md
@@ -15,6 +15,16 @@ search:
 !!! quote ""
     Thanks to [*typer*](https://typer.tiangolo.com/){.external-link target="_blank"} and [*watchfiles*](https://watchfiles.helpmanual.io/){.external-link target="_blank"}. Their work is the basis of this tool.
 
+## Installation
+
+To install the **FastStream CLI**, you need to run the following command:
+
+```shell
+pip install faststream[cli]
+```
+
+After installation, you can check which commands are available by executing:
+
 ```shell
 faststream --help
 ```

--- a/docs/docs/navigation_template.txt
+++ b/docs/docs/navigation_template.txt
@@ -41,7 +41,7 @@ search:
         - [HTTP Async Frameworks](getting-started/integrations/frameworks/index.md)
         - [FastAPI Plugin](getting-started/integrations/fastapi/index.md)
         - [Django](getting-started/integrations/django/index.md)
-    - [CLI commands](getting-started/cli/index.md)
+    - [CLI](getting-started/cli/index.md)
     - [ASGI](getting-started/asgi.md)
     - [OpenTelemetry](getting-started/opentelemetry/index.md)
     - [Logging](getting-started/logging.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ dynamic = ["version"]
 dependencies = [
     "anyio>=3.7.1,<5",
     "fast-depends>=2.4.0b0,<2.5.0",
-    "typer>=0.9,!=0.12,<1",
     "typing-extensions>=4.8.0",
 ]
 
@@ -75,8 +74,13 @@ redis = ["redis>=5.0.0,<6.0.0"]
 
 otel = ["opentelemetry-sdk>=1.24.0,<2.0.0"]
 
+cli = [
+    "typer>=0.9,!=0.12,<1",
+    "watchfiles==0.24.0"
+]
+
 # dev dependencies
-optionals = ["faststream[rabbit,kafka,confluent,nats,redis,otel]"]
+optionals = ["faststream[rabbit,kafka,confluent,nats,redis,otel,cli]"]
 
 devdocs = [
     "mkdocs-material==9.5.34",
@@ -132,7 +136,6 @@ testing = [
     "pydantic-settings>=2.0.0,<3.0.0",
     "httpx==0.27.2",
     "PyYAML==6.0.2",
-    "watchfiles==0.24.0",
     "email-validator==2.2.0",
 ]
 


### PR DESCRIPTION
# Description

This PR makes Faststream CLI be available in it's own distribution installing via `pip install fastream[cli]`.

Besides moving to it's own distribuition, also move the `whatchfiles` dependency from `testing `to `cli`.

Lastly updated the documentation, on section where CLI is referenced, to mention how to install.

Fixes #1430 

## Type of change

- [X] Documentation (typos, code examples, or any documentation updates)
- [X] New feature (a non-breaking change that adds functionality)
- [X] This change requires a documentation update

## Checklist

- [X] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [X] I have conducted a self-review of my own code
- [X] I have made the necessary changes to the documentation
- [X] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [X] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [X] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [X] I have included code examples to illustrate the modifications
