### PR TITLE
Fixes the CI bug that allows PRs with failed tests to be merged.

### DIFF
--- a/.github/workflows/pr_tests.yaml
+++ b/.github/workflows/pr_tests.yaml
@@ -481,7 +481,13 @@ jobs:
 
   # https://github.com/marketplace/actions/alls-green#why
   check: # This job does nothing and is only used for the branch protection
-    if: github.event.pull_request.draft == false
+    # from: https://github.com/re-actors/alls-green
+    # Important: For this to work properly, it is a must to have the job always
+    # run, otherwise GitHub will make it skipped when any of the dependencies
+    # fail. In some contexts, skipped is interpreted as success which may lead
+    # to undesired, unobvious and even dangerous (as in security breach
+    # "dangerous") side-effects.
+    if: always()
 
     needs:
       - pre-commit-check


### PR DESCRIPTION
# Description

For `check` to work properly, it is a must to have the job always run, otherwise GitHub will make it skipped when any of the dependencies fail. In some contexts, skipped is interpreted as success which may lead to undersired, unobvious and even dangerous (as in security breach "dangerous") side-effects.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] I have conducted a self-review of my own code
- [x] My changes do not generate any new warnings
