### PR TITLE
Autocommit precommit changes

### DIFF
--- a/.github/workflows/pr_tests.yaml
+++ b/.github/workflows/pr_tests.yaml
@@ -41,6 +41,14 @@ jobs:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ hashFiles('.pre-commit-config.yaml') }}
       - uses: pre-commit/action@v3.0.1
+        continue-on-error: true
+        with:
+          extra_args: --hook-stage manual --all-files
+      - name: Commit
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "fix: add missing pre-commit changes"
+      - uses: pre-commit/action@v3.0.1
 
   test-basic:
     if: github.event.pull_request.draft == false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,24 +1,30 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+default_stages: [pre-commit, pre-merge-commit]
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:
     -   id: trailing-whitespace
+        stages: [pre-commit, pre-merge-commit, manual]
     -   id: end-of-file-fixer
+        stages: [pre-commit, pre-merge-commit, manual]
         exclude: |
             (?x)^(
                 docs/docs/SUMMARY.md|
                 docs/docs/en/api/.meta.yml
             )$
     -   id: check-yaml
+        stages: [pre-commit, pre-merge-commit, manual]
         exclude: 'docs/mkdocs.yml'
     -   id: check-added-large-files
+        stages: [pre-commit, pre-merge-commit, manual]
 
 -   repo: https://github.com/codespell-project/codespell
     rev: v2.3.0
     hooks:
     -   id: codespell
+        stages: [pre-commit, pre-merge-commit, manual]
         args: [--ignore-words=.codespell-whitelist.txt]
         exclude: |
             (?x)^(
@@ -29,6 +35,7 @@ repos:
     hooks:
     -   id: lint
         name: Linter
+        stages: [pre-commit, pre-merge-commit, manual]
         entry: "scripts/lint-pre-commit.sh"
         language: python
         language_version: python3.8


### PR DESCRIPTION
# Description

Pre-commit can fail with two types of errors - 1. auto fixable(linting, codespell, etc), 2. manually fixable(mypy, semgrep, etc).
We can auto commit changes only if the failure is because of 1. auto fixable failure.

@Lancetnik I took an approach here where I run the `auto fixable` hooks alone first, commit next and then run everything again.

There could be an alternative approach too. Run everything first, commit and then raise error. Please review the changes and decide which approach you want to take.

Fixes #1814 

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [ ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
