### PR TITLE
Replace async Event with bool

### DIFF
--- a/faststream/_internal/application.py
+++ b/faststream/_internal/application.py
@@ -162,7 +162,7 @@ class Application(ABC, AsyncAPIApplication):
 
     async def _main_loop(self, sleep_time: float) -> None:
         """Run loop till exit signal."""
-        while not self._should_exit:
+        while not self._should_exit:  # noqa: ASYNC110 (requested by creator)
             await asyncio.sleep(sleep_time)
 
     async def start(

--- a/faststream/_internal/application.py
+++ b/faststream/_internal/application.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 from abc import ABC, abstractmethod
 from typing import (
@@ -13,6 +12,7 @@ from typing import (
     Union,
 )
 
+import anyio
 from typing_extensions import ParamSpec
 
 from faststream.asyncapi.proto import AsyncAPIApplication
@@ -163,7 +163,7 @@ class Application(ABC, AsyncAPIApplication):
     async def _main_loop(self, sleep_time: float) -> None:
         """Run loop till exit signal."""
         while not self._should_exit:  # noqa: ASYNC110 (requested by creator)
-            await asyncio.sleep(sleep_time)
+            await anyio.sleep(sleep_time)
 
     async def start(
         self,

--- a/faststream/app.py
+++ b/faststream/app.py
@@ -10,7 +10,7 @@ from typing import (
 )
 
 import anyio
-from typing_extensions import Annotated, ParamSpec, deprecated
+from typing_extensions import ParamSpec
 
 from faststream._compat import ExceptionGroup
 from faststream._internal.application import Application
@@ -35,13 +35,7 @@ class FastStream(Application):
         self,
         log_level: int = logging.INFO,
         run_extra_options: Optional[Dict[str, "SettingField"]] = None,
-        sleep_time: Annotated[
-            float,
-            deprecated(
-                "Deprecated in **FastStream 0.5.24**. "
-                "Argument will be removed in **FastStream 0.6.0**."
-            ),
-        ] = 0.1,
+        sleep_time: float = 0.1,
     ) -> None:
         """Run FastStream Application."""
         assert self.broker, "You should setup a broker"  # nosec B101
@@ -54,7 +48,7 @@ class FastStream(Application):
             try:
                 async with anyio.create_task_group() as tg:
                     tg.start_soon(self._startup, log_level, run_extra_options)
-                    await self._should_exit.wait()
+                    await self._main_loop(sleep_time)
                     await self._shutdown(log_level)
                     tg.cancel_scope.cancel()
             except ExceptionGroup as e:


### PR DESCRIPTION
# Description

@Lancetnik asked to replace the awaiting of `asyncio.Event` in favor of `asyncio.sleep` in a loop, so that the implementation would be similar to uvicorn:
https://github.com/encode/uvicorn/blob/079f07a06457717b6f8c4b23bab7674d5f0568c1/uvicorn/server.py#L222-L229

The solution with `asyncio.Event` in the `__init__` did not allow amateurs to use global object storage to use the library correctly, cause event instance became attached to another event loop.

I proposed an option to ensure compatibility with the use of `asyncio.Event` with lazy creation, but @Lancetnik asked for `asyncio.sleep` only. So I copy solution from unicorn.

Fixes #1837

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [x] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [x] I have included code examples to illustrate the modifications
