### PR TITLE
docs: Correct minimum FastAPI version for lifespan handling

### DIFF
--- a/docs/docs/en/getting-started/integrations/fastapi/index.md
+++ b/docs/docs/en/getting-started/integrations/fastapi/index.md
@@ -27,7 +27,7 @@ Just import a **StreamRouter** you need and declare the message handler in the s
 {! includes/getting_started/integrations/fastapi/1.md !}
 
 !!! warning
-    If you are using **fastapi < 0.102.2** version, you should setup lifespan manually `#!python FastAPI(lifespan=router.lifespan_context)`
+    If you are using **fastapi < 0.112.2** version, you should setup lifespan manually `#!python FastAPI(lifespan=router.lifespan_context)`
 
 When processing a message from a broker, the entire message body is placed simultaneously in both the `body` and `path` request parameters. You can access them in any way convenient for you. The message header is placed in `headers`.
 


### PR DESCRIPTION
# Description

Based on the git blame and https://github.com/airtai/faststream/pull/1736, I believe the minimum version of FastAPI for handling lifespan functions correctly is `112.2`, not `102.2`. Just ran into this trying to work out why our broker was never getting connected on an older (103) FastAPI install.

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [ ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
