### PR TITLE
fastapi example update

### DIFF
--- a/examples/fastapi_integration/app.py
+++ b/examples/fastapi_integration/app.py
@@ -3,7 +3,7 @@ from fastapi import FastAPI
 from faststream.rabbit.fastapi import Logger, RabbitRouter
 
 router = RabbitRouter("amqp://guest:guest@localhost:5672/")
-app = FastAPI(lifespan=router.lifespan_context)
+app = FastAPI()
 
 publisher = router.publisher("response-q")
 


### PR DESCRIPTION
# Description

Since FastAPI 0.112.2 it is not necessary to specify lifespan_context manually.