### PR TITLE
Add support for environment variables in faststream run command

### DIFF
--- a/faststream/cli/main.py
+++ b/faststream/cli/main.py
@@ -66,11 +66,13 @@ def run(
         1,
         show_default=False,
         help="Run [workers] applications with process spawning.",
+        envvar="FASTSTREAM_WORKERS",
     ),
     log_level: LogLevels = typer.Option(
         LogLevels.notset,
         case_sensitive=False,
         help="Set selected level for FastStream and brokers logger objects.",
+        envvar="FASTSTREAM_LOG_LEVEL",
     ),
     reload: bool = typer.Option(
         False,
@@ -93,6 +95,7 @@ def run(
             "Look for APP in the specified directory, by adding this to the PYTHONPATH."
             " Defaults to the current working directory."
         ),
+        envvar="FASTSTREAM_APP_DIR",
     ),
     is_factory: bool = typer.Option(
         False,


### PR DESCRIPTION
# Description

- `FASTSTREAM_WORKERS` as an alternative to the `--workers` argument
- `FASTSTREAM_APP_DIR` as an alternative to `--app-dir`
- `FASTSTREAM_LOG_LEVEL` as an alternative to `--log-level`

Fixes # (issue number)

## Type of change

Please delete options that are not relevant.

- [x] New feature (a non-breaking change that adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
