### PR TITLE
Fixed RPC for Prometheus metrics

### DIFF
--- a/faststream/prometheus/middleware.py
+++ b/faststream/prometheus/middleware.py
@@ -88,7 +88,7 @@ class _PrometheusMiddleware(BaseMiddleware):
         call_next: "AsyncFuncAny",
         msg: "StreamMessage[Any]",
     ) -> Any:
-        if self._settings_provider is None or msg._source_type == SourceType.Response:
+        if self._settings_provider is None or msg._source_type is SourceType.Response:
             return await call_next(msg)
 
         messaging_system = self._settings_provider.messaging_system
@@ -165,7 +165,7 @@ class _PrometheusMiddleware(BaseMiddleware):
         call_next: "AsyncFunc",
         cmd: "PublishCommand",
     ) -> Any:
-        if self._settings_provider is None or cmd.publish_type == PublishType.Reply:
+        if self._settings_provider is None or cmd.publish_type is PublishType.Reply:
             return await call_next(cmd)
 
         destination_name = (

--- a/faststream/prometheus/middleware.py
+++ b/faststream/prometheus/middleware.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from faststream import BaseMiddleware
 from faststream._internal.constants import EMPTY
+from faststream.message import SourceType
 from faststream.prometheus.consts import (
     PROCESSING_STATUS_BY_ACK_STATUS,
     PROCESSING_STATUS_BY_HANDLER_EXCEPTION_MAP,
@@ -12,6 +13,7 @@ from faststream.prometheus.container import MetricsContainer
 from faststream.prometheus.manager import MetricsManager
 from faststream.prometheus.provider import MetricsSettingsProvider
 from faststream.prometheus.types import ProcessingStatus, PublishingStatus
+from faststream.response import PublishType
 
 if TYPE_CHECKING:
     from prometheus_client import CollectorRegistry
@@ -86,7 +88,7 @@ class _PrometheusMiddleware(BaseMiddleware):
         call_next: "AsyncFuncAny",
         msg: "StreamMessage[Any]",
     ) -> Any:
-        if self._settings_provider is None:
+        if self._settings_provider is None or msg._source_type == SourceType.Response:
             return await call_next(msg)
 
         messaging_system = self._settings_provider.messaging_system
@@ -163,7 +165,7 @@ class _PrometheusMiddleware(BaseMiddleware):
         call_next: "AsyncFunc",
         cmd: "PublishCommand",
     ) -> Any:
-        if self._settings_provider is None:
+        if self._settings_provider is None or cmd.publish_type == PublishType.Reply:
             return await call_next(cmd)
 
         destination_name = (

--- a/tests/prometheus/nats/test_nats.py
+++ b/tests/prometheus/nats/test_nats.py
@@ -9,7 +9,7 @@ from faststream.nats import JStream, NatsBroker, PullSub
 from faststream.nats.prometheus.middleware import NatsPrometheusMiddleware
 from tests.brokers.nats.test_consume import TestConsume
 from tests.brokers.nats.test_publish import TestPublish
-from tests.prometheus.basic import LocalPrometheusTestcase
+from tests.prometheus.basic import LocalPrometheusTestcase, LocalRPCPrometheusTestcase
 
 
 @pytest.fixture()
@@ -18,7 +18,7 @@ def stream(queue):
 
 
 @pytest.mark.nats()
-class TestPrometheus(LocalPrometheusTestcase):
+class TestPrometheus(LocalPrometheusTestcase, LocalRPCPrometheusTestcase):
     def get_broker(self, apply_types=False, **kwargs):
         return NatsBroker(apply_types=apply_types, **kwargs)
 

--- a/tests/prometheus/rabbit/test_rabbit.py
+++ b/tests/prometheus/rabbit/test_rabbit.py
@@ -5,7 +5,7 @@ from faststream.rabbit import RabbitBroker, RabbitExchange
 from faststream.rabbit.prometheus.middleware import RabbitPrometheusMiddleware
 from tests.brokers.rabbit.test_consume import TestConsume
 from tests.brokers.rabbit.test_publish import TestPublish
-from tests.prometheus.basic import LocalPrometheusTestcase
+from tests.prometheus.basic import LocalPrometheusTestcase, LocalRPCPrometheusTestcase
 
 
 @pytest.fixture()
@@ -14,7 +14,7 @@ def exchange(queue):
 
 
 @pytest.mark.rabbit()
-class TestPrometheus(LocalPrometheusTestcase):
+class TestPrometheus(LocalPrometheusTestcase, LocalRPCPrometheusTestcase):
     def get_broker(self, apply_types=False, **kwargs):
         return RabbitBroker(apply_types=apply_types, **kwargs)
 

--- a/tests/prometheus/redis/test_redis.py
+++ b/tests/prometheus/redis/test_redis.py
@@ -9,11 +9,11 @@ from faststream.redis import ListSub, RedisBroker
 from faststream.redis.prometheus.middleware import RedisPrometheusMiddleware
 from tests.brokers.redis.test_consume import TestConsume
 from tests.brokers.redis.test_publish import TestPublish
-from tests.prometheus.basic import LocalPrometheusTestcase
+from tests.prometheus.basic import LocalPrometheusTestcase, LocalRPCPrometheusTestcase
 
 
 @pytest.mark.redis()
-class TestPrometheus(LocalPrometheusTestcase):
+class TestPrometheus(LocalPrometheusTestcase, LocalRPCPrometheusTestcase):
     def get_broker(self, apply_types=False, **kwargs):
         return RedisBroker(apply_types=apply_types, **kwargs)
 


### PR DESCRIPTION
# Description

For RPC, the metrics incorrectly included messages from temporary queues/subjects. 
Now, when publishing, `Reply` messages are ignored and when consuming, `Response` messages are ignored.

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
