### PR TITLE
Allow using aiokafka 0.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dependencies = [
 # public distributions
 rabbit = ["aio-pika>=9,<10"]
 
-kafka = ["aiokafka>=0.9,<0.12"]
+kafka = ["aiokafka>=0.9,<0.13"]
 
 confluent = [
     "confluent-kafka>=2,<3; python_version < '3.13'",


### PR DESCRIPTION
# Description

AIOKafka 0.12 was released 2 weeks ago, and provides wheels for Python 3.13:
https://github.com/aio-libs/aiokafka/releases/tag/v0.12.0

Current change allows installing this version.

## Type of change

Dependency update.

## Checklist

- [X] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [X] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [X] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
