### PR TITLE
Introducing FastStream Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@
     <img src="https://img.shields.io/pypi/pyversions/faststream.svg" alt="Supported Python versions"/>
   </a>
 
+  <a href="https://gurubase.io/g/faststream" target="_blank">
+    <img src="https://img.shields.io/badge/Gurubase-Ask%20FastStream%20Guru-006BFF" alt="Gurubase"/>
+  </a>
+
   <br/>
 
   <a href="https://github.com/airtai/faststream/actions/workflows/pr_codeql.yaml" target="_blank">


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [FastStream Guru](https://gurubase.io/g/faststream) to Gurubase. FastStream Guru uses the data from this repo and data from the [docs](https://faststream.airt.ai/latest/) to answer questions by leveraging the LLM.

In this PR, I showcased the "FastStream Guru", which highlights that FastStream now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable FastStream Guru in Gurubase, just let me know that's totally fine.
