### PR TITLE
fix: allow users to pass `nkeys_seed_str` as argument for NATS broker.

### DIFF
--- a/faststream/__about__.py
+++ b/faststream/__about__.py
@@ -1,5 +1,5 @@
 """Simple and fast framework to create message brokers based microservices."""
 
-__version__ = "0.5.29"
+__version__ = "0.5.30"
 
 SERVICE_NAME = f"faststream-{__version__}"

--- a/faststream/nats/broker/broker.py
+++ b/faststream/nats/broker/broker.py
@@ -195,6 +195,10 @@ if TYPE_CHECKING:
         ]
         nkeys_seed: Annotated[
             Optional[str],
+            Doc("Path-like object containing nkeys seed that will be used."),
+        ]
+        nkeys_seed_str: Annotated[
+            Optional[str],
             Doc("Nkeys seed to be used."),
         ]
         inbox_prefix: Annotated[
@@ -350,8 +354,12 @@ class NatsBroker(
         ] = None,
         nkeys_seed: Annotated[
             Optional[str],
-            Doc("Nkeys seed to be used."),
+            Doc("Path-like object containing nkeys seed that will be used."),
         ] = None,
+        nkeys_seed_str: Annotated[
+            Optional[str],
+            Doc("Raw nkeys seed to be used."),
+        ],
         inbox_prefix: Annotated[
             Union[str, bytes],
             Doc(
@@ -509,6 +517,7 @@ class NatsBroker(
             token=token,
             user_credentials=user_credentials,
             nkeys_seed=nkeys_seed,
+            nkeys_seed_str=nkeys_seed_str,
             **secure_kwargs,
             # callbacks
             error_cb=self._log_connection_broken(error_cb),

--- a/faststream/nats/broker/broker.py
+++ b/faststream/nats/broker/broker.py
@@ -359,7 +359,7 @@ class NatsBroker(
         nkeys_seed_str: Annotated[
             Optional[str],
             Doc("Raw nkeys seed to be used."),
-        ],
+        ] = None,
         inbox_prefix: Annotated[
             Union[str, bytes],
             Doc(


### PR DESCRIPTION
This would simplify the usage of applications without a need to read files.

# Description

Please include a summary of the change and specify which issue is being addressed. Additionally, provide relevant motivation and context.

Fixes # (issue number)

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
