### PR TITLE
Feature: add NatsMessage ack_sync method #1906

### DIFF
--- a/docs/docs/en/release.md
+++ b/docs/docs/en/release.md
@@ -12,6 +12,21 @@ hide:
 ---
 
 # Release Notes
+## 0.5.30
+
+### What's Changed
+* Introducing FastStream Guru on Gurubase.io by [@kursataktas](https://github.com/kursataktas){.external-link target="_blank"} in [#1903](https://github.com/airtai/faststream/pull/1903){.external-link target="_blank"}
+* docs: add gurubase badge to the doc by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#1905](https://github.com/airtai/faststream/pull/1905){.external-link target="_blank"}
+* fix: allow users to pass `nkeys_seed_str` as argument for NATS broker. by [@Drakorgaur](https://github.com/Drakorgaur){.external-link target="_blank"} in [#1908](https://github.com/airtai/faststream/pull/1908){.external-link target="_blank"}
+* Add more warning's to nats subscription factory by [@sheldygg](https://github.com/sheldygg){.external-link target="_blank"} in [#1907](https://github.com/airtai/faststream/pull/1907){.external-link target="_blank"}
+* fix: correct working with dependencies versions by [@Lancetnik](https://github.com/Lancetnik){.external-link target="_blank"} in [#1918](https://github.com/airtai/faststream/pull/1918){.external-link target="_blank"}
+
+### New Contributors
+* [@kursataktas](https://github.com/kursataktas){.external-link target="_blank"} made their first contribution in [#1903](https://github.com/airtai/faststream/pull/1903){.external-link target="_blank"}
+* [@Drakorgaur](https://github.com/Drakorgaur){.external-link target="_blank"} made their first contribution in [#1908](https://github.com/airtai/faststream/pull/1908){.external-link target="_blank"}
+
+**Full Changelog**: [#0.5.29...0.5.30](https://github.com/airtai/faststream/compare/0.5.29...0.5.30){.external-link target="_blank"}
+
 ## 0.5.29
 
 ### What's Changed

--- a/faststream/nats/message.py
+++ b/faststream/nats/message.py
@@ -17,6 +17,11 @@ class NatsMessage(StreamMessage[Msg]):
             await self.raw_message.ack()
         await super().ack()
 
+    def ack_sync(self) -> None:
+        if not self.raw_message._ackd:
+            self.raw_message.ack()
+        super().ack()
+
     async def nack(
         self,
         delay: Union[int, float, None] = None,

--- a/faststream/nats/message.py
+++ b/faststream/nats/message.py
@@ -17,10 +17,10 @@ class NatsMessage(StreamMessage[Msg]):
             await self.raw_message.ack()
         await super().ack()
 
-    def ack_sync(self) -> None:
+    async def ack_sync(self) -> None:
         if not self.raw_message._ackd:
-            self.raw_message.ack_sync()
-        super().ack()
+            await self.raw_message.ack_sync()
+        await super().ack()
 
     async def nack(
         self,

--- a/faststream/nats/message.py
+++ b/faststream/nats/message.py
@@ -19,7 +19,7 @@ class NatsMessage(StreamMessage[Msg]):
 
     def ack_sync(self) -> None:
         if not self.raw_message._ackd:
-            self.raw_message.ack()
+            self.raw_message.ack_sync()
         super().ack()
 
     async def nack(


### PR DESCRIPTION
Description
Added the ack_sync method to NatsMessage to support synchronous acknowledgment functionality.

Fixes #1906

Type of Change
 New feature (a non-breaking change that adds functionality)
Checklist
 My code adheres to the style guidelines of this project (scripts/lint.sh shows no errors)
 I have conducted a self-review of my own code
 I have ensured that static analysis tests are passing by running scripts/static-analysis.sh
