### PR TITLE
fixed a bug when using one register for several middleware

### DIFF
--- a/faststream/prometheus/container.py
+++ b/faststream/prometheus/container.py
@@ -56,6 +56,7 @@ class MetricsContainer:
             labelnames=["app_name", "broker", "handler"],
             registry=registry,
         )
+
         self.received_messages_size_bytes = cast(
             Histogram,
             self._get_registered_metric(
@@ -68,6 +69,7 @@ class MetricsContainer:
             registry=registry,
             buckets=received_messages_size_buckets or self.DEFAULT_SIZE_BUCKETS,
         )
+
         self.received_messages_in_process = cast(
             Gauge,
             self._get_registered_metric(
@@ -79,6 +81,7 @@ class MetricsContainer:
             labelnames=["app_name", "broker", "handler"],
             registry=registry,
         )
+
         self.received_processed_messages_total = cast(
             Counter,
             self._get_registered_metric(
@@ -90,6 +93,7 @@ class MetricsContainer:
             labelnames=["app_name", "broker", "handler", "status"],
             registry=registry,
         )
+
         self.received_processed_messages_duration_seconds = cast(
             Histogram,
             self._get_registered_metric(
@@ -101,6 +105,7 @@ class MetricsContainer:
             labelnames=["app_name", "broker", "handler"],
             registry=registry,
         )
+
         self.received_processed_messages_exceptions_total = cast(
             Counter,
             self._get_registered_metric(
@@ -112,6 +117,7 @@ class MetricsContainer:
             labelnames=["app_name", "broker", "handler", "exception_type"],
             registry=registry,
         )
+
         self.published_messages_total = cast(
             Counter,
             self._get_registered_metric(f"{metrics_prefix}_published_messages_total"),
@@ -121,6 +127,7 @@ class MetricsContainer:
             labelnames=["app_name", "broker", "destination", "status"],
             registry=registry,
         )
+
         self.published_messages_duration_seconds = cast(
             Histogram,
             self._get_registered_metric(

--- a/faststream/prometheus/container.py
+++ b/faststream/prometheus/container.py
@@ -1,6 +1,10 @@
-from typing import Optional, Sequence
+from typing import TYPE_CHECKING, Optional, Sequence, Union
 
-from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram
+from prometheus_client import Counter, Gauge, Histogram
+
+if TYPE_CHECKING:
+    from prometheus_client import CollectorRegistry
+    from prometheus_client.metrics import MetricWrapperBase
 
 
 class MetricsContainer:
@@ -43,58 +47,82 @@ class MetricsContainer:
         self._registry = registry
         self._metrics_prefix = metrics_prefix
 
-        self.received_messages_total = Counter(
+        self.received_messages_total = self._get_registered_metric(
+            f"{metrics_prefix}_received_messages_total"
+        ) or Counter(
             name=f"{metrics_prefix}_received_messages_total",
             documentation="Count of received messages by broker and handler",
             labelnames=["app_name", "broker", "handler"],
             registry=registry,
         )
-        self.received_messages_size_bytes = Histogram(
+        self.received_messages_size_bytes = self._get_registered_metric(
+            f"{metrics_prefix}_received_messages_size_bytes"
+        ) or Histogram(
             name=f"{metrics_prefix}_received_messages_size_bytes",
             documentation="Histogram of received messages size in bytes by broker and handler",
             labelnames=["app_name", "broker", "handler"],
             registry=registry,
             buckets=received_messages_size_buckets or self.DEFAULT_SIZE_BUCKETS,
         )
-        self.received_messages_in_process = Gauge(
+        self.received_messages_in_process = self._get_registered_metric(
+            f"{metrics_prefix}_received_messages_in_process"
+        ) or Gauge(
             name=f"{metrics_prefix}_received_messages_in_process",
             documentation="Gauge of received messages in process by broker and handler",
             labelnames=["app_name", "broker", "handler"],
             registry=registry,
         )
-        self.received_processed_messages_total = Counter(
+        self.received_processed_messages_total = self._get_registered_metric(
+            f"{metrics_prefix}_received_processed_messages_total"
+        ) or Counter(
             name=f"{metrics_prefix}_received_processed_messages_total",
             documentation="Count of received processed messages by broker, handler and status",
             labelnames=["app_name", "broker", "handler", "status"],
             registry=registry,
         )
-        self.received_processed_messages_duration_seconds = Histogram(
+        self.received_processed_messages_duration_seconds = self._get_registered_metric(
+            f"{metrics_prefix}_received_processed_messages_duration_seconds"
+        ) or Histogram(
             name=f"{metrics_prefix}_received_processed_messages_duration_seconds",
             documentation="Histogram of received processed messages duration in seconds by broker and handler",
             labelnames=["app_name", "broker", "handler"],
             registry=registry,
         )
-        self.received_processed_messages_exceptions_total = Counter(
+        self.received_processed_messages_exceptions_total = self._get_registered_metric(
+            f"{metrics_prefix}_received_processed_messages_exceptions_total"
+        ) or Counter(
             name=f"{metrics_prefix}_received_processed_messages_exceptions_total",
             documentation="Count of received processed messages exceptions by broker, handler and exception_type",
             labelnames=["app_name", "broker", "handler", "exception_type"],
             registry=registry,
         )
-        self.published_messages_total = Counter(
+        self.published_messages_total = self._get_registered_metric(
+            f"{metrics_prefix}_published_messages_total"
+        ) or Counter(
             name=f"{metrics_prefix}_published_messages_total",
             documentation="Count of published messages by destination and status",
             labelnames=["app_name", "broker", "destination", "status"],
             registry=registry,
         )
-        self.published_messages_duration_seconds = Histogram(
+        self.published_messages_duration_seconds = self._get_registered_metric(
+            f"{metrics_prefix}_published_messages_duration_seconds"
+        ) or Histogram(
             name=f"{metrics_prefix}_published_messages_duration_seconds",
             documentation="Histogram of published messages duration in seconds by broker and destination",
             labelnames=["app_name", "broker", "destination"],
             registry=registry,
         )
-        self.published_messages_exceptions_total = Counter(
+
+        self.published_messages_exceptions_total = self._get_registered_metric(
+            f"{metrics_prefix}_published_messages_exceptions_total"
+        ) or Counter(
             name=f"{metrics_prefix}_published_messages_exceptions_total",
             documentation="Count of published messages exceptions by broker, destination and exception_type",
             labelnames=["app_name", "broker", "destination", "exception_type"],
             registry=registry,
         )
+
+    def _get_registered_metric(
+        self, metric_name: str
+    ) -> Union["MetricWrapperBase", None]:
+        return self._registry._names_to_collectors.get(metric_name)

--- a/faststream/prometheus/container.py
+++ b/faststream/prometheus/container.py
@@ -1,10 +1,10 @@
-from typing import TYPE_CHECKING, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Optional, Sequence, Union, cast
 
 from prometheus_client import Counter, Gauge, Histogram
 
 if TYPE_CHECKING:
     from prometheus_client import CollectorRegistry
-    from prometheus_client.metrics import MetricWrapperBase
+    from prometheus_client.registry import Collector
 
 
 class MetricsContainer:
@@ -47,16 +47,20 @@ class MetricsContainer:
         self._registry = registry
         self._metrics_prefix = metrics_prefix
 
-        self.received_messages_total = self._get_registered_metric(
-            f"{metrics_prefix}_received_messages_total"
+        self.received_messages_total = cast(
+            Counter,
+            self._get_registered_metric(f"{metrics_prefix}_received_messages_total"),
         ) or Counter(
             name=f"{metrics_prefix}_received_messages_total",
             documentation="Count of received messages by broker and handler",
             labelnames=["app_name", "broker", "handler"],
             registry=registry,
         )
-        self.received_messages_size_bytes = self._get_registered_metric(
-            f"{metrics_prefix}_received_messages_size_bytes"
+        self.received_messages_size_bytes = cast(
+            Histogram,
+            self._get_registered_metric(
+                f"{metrics_prefix}_received_messages_size_bytes"
+            ),
         ) or Histogram(
             name=f"{metrics_prefix}_received_messages_size_bytes",
             documentation="Histogram of received messages size in bytes by broker and handler",
@@ -64,48 +68,64 @@ class MetricsContainer:
             registry=registry,
             buckets=received_messages_size_buckets or self.DEFAULT_SIZE_BUCKETS,
         )
-        self.received_messages_in_process = self._get_registered_metric(
-            f"{metrics_prefix}_received_messages_in_process"
+        self.received_messages_in_process = cast(
+            Gauge,
+            self._get_registered_metric(
+                f"{metrics_prefix}_received_messages_in_process"
+            ),
         ) or Gauge(
             name=f"{metrics_prefix}_received_messages_in_process",
             documentation="Gauge of received messages in process by broker and handler",
             labelnames=["app_name", "broker", "handler"],
             registry=registry,
         )
-        self.received_processed_messages_total = self._get_registered_metric(
-            f"{metrics_prefix}_received_processed_messages_total"
+        self.received_processed_messages_total = cast(
+            Counter,
+            self._get_registered_metric(
+                f"{metrics_prefix}_received_processed_messages_total"
+            ),
         ) or Counter(
             name=f"{metrics_prefix}_received_processed_messages_total",
             documentation="Count of received processed messages by broker, handler and status",
             labelnames=["app_name", "broker", "handler", "status"],
             registry=registry,
         )
-        self.received_processed_messages_duration_seconds = self._get_registered_metric(
-            f"{metrics_prefix}_received_processed_messages_duration_seconds"
+        self.received_processed_messages_duration_seconds = cast(
+            Histogram,
+            self._get_registered_metric(
+                f"{metrics_prefix}_received_processed_messages_duration_seconds"
+            ),
         ) or Histogram(
             name=f"{metrics_prefix}_received_processed_messages_duration_seconds",
             documentation="Histogram of received processed messages duration in seconds by broker and handler",
             labelnames=["app_name", "broker", "handler"],
             registry=registry,
         )
-        self.received_processed_messages_exceptions_total = self._get_registered_metric(
-            f"{metrics_prefix}_received_processed_messages_exceptions_total"
+        self.received_processed_messages_exceptions_total = cast(
+            Counter,
+            self._get_registered_metric(
+                f"{metrics_prefix}_received_processed_messages_exceptions_total"
+            ),
         ) or Counter(
             name=f"{metrics_prefix}_received_processed_messages_exceptions_total",
             documentation="Count of received processed messages exceptions by broker, handler and exception_type",
             labelnames=["app_name", "broker", "handler", "exception_type"],
             registry=registry,
         )
-        self.published_messages_total = self._get_registered_metric(
-            f"{metrics_prefix}_published_messages_total"
+        self.published_messages_total = cast(
+            Counter,
+            self._get_registered_metric(f"{metrics_prefix}_published_messages_total"),
         ) or Counter(
             name=f"{metrics_prefix}_published_messages_total",
             documentation="Count of published messages by destination and status",
             labelnames=["app_name", "broker", "destination", "status"],
             registry=registry,
         )
-        self.published_messages_duration_seconds = self._get_registered_metric(
-            f"{metrics_prefix}_published_messages_duration_seconds"
+        self.published_messages_duration_seconds = cast(
+            Histogram,
+            self._get_registered_metric(
+                f"{metrics_prefix}_published_messages_duration_seconds"
+            ),
         ) or Histogram(
             name=f"{metrics_prefix}_published_messages_duration_seconds",
             documentation="Histogram of published messages duration in seconds by broker and destination",
@@ -113,8 +133,11 @@ class MetricsContainer:
             registry=registry,
         )
 
-        self.published_messages_exceptions_total = self._get_registered_metric(
-            f"{metrics_prefix}_published_messages_exceptions_total"
+        self.published_messages_exceptions_total = cast(
+            Counter,
+            self._get_registered_metric(
+                f"{metrics_prefix}_published_messages_exceptions_total"
+            ),
         ) or Counter(
             name=f"{metrics_prefix}_published_messages_exceptions_total",
             documentation="Count of published messages exceptions by broker, destination and exception_type",
@@ -122,7 +145,5 @@ class MetricsContainer:
             registry=registry,
         )
 
-    def _get_registered_metric(
-        self, metric_name: str
-    ) -> Union["MetricWrapperBase", None]:
+    def _get_registered_metric(self, metric_name: str) -> Union["Collector", None]:
         return self._registry._names_to_collectors.get(metric_name)

--- a/faststream/prometheus/middleware.py
+++ b/faststream/prometheus/middleware.py
@@ -1,5 +1,5 @@
 import time
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence
 
 from faststream import BaseMiddleware
 from faststream.prometheus.consts import (
@@ -167,8 +167,6 @@ class PrometheusMiddleware(BaseMiddleware):
 
 
 class BasePrometheusMiddleware:
-    _container_by_registry: ClassVar[Dict["CollectorRegistry", MetricsContainer]] = {}
-
     __slots__ = ("_metrics_container", "_metrics_manager", "_settings_provider_factory")
 
     def __init__(
@@ -186,17 +184,11 @@ class BasePrometheusMiddleware:
             app_name = metrics_prefix
 
         self._settings_provider_factory = settings_provider_factory
-
-        if registry in self._container_by_registry:
-            self._metrics_container = self._container_by_registry[registry]
-        else:
-            self._metrics_container = MetricsContainer(
-                registry,
-                metrics_prefix=metrics_prefix,
-                received_messages_size_buckets=received_messages_size_buckets,
-            )
-            self._container_by_registry[registry] = self._metrics_container
-
+        self._metrics_container = MetricsContainer(
+            registry,
+            metrics_prefix=metrics_prefix,
+            received_messages_size_buckets=received_messages_size_buckets,
+        )
         self._metrics_manager = MetricsManager(
             self._metrics_container,
             app_name=app_name,


### PR DESCRIPTION
# Description

If you use one register for several middleware, then a metric registration conflict occurs.

Error:
```
ValueError: Duplicated timeseries in CollectorRegistry: {'faststream_received_messages_created', 'faststream_received_messages', 'faststream_received_messages_total'}
```

[The error occurs here](https://github.com/airtai/faststream/blob/main/faststream/prometheus/container.py#L50) when trying to register a duplicate metric into a register


## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [x] I have included code examples to illustrate the modifications
