### PR TITLE
feat: support running ASGI app with Uvicorn using file descriptor

### DIFF
--- a/faststream/asgi/app.py
+++ b/faststream/asgi/app.py
@@ -153,12 +153,14 @@ class AsgiFastStream(Application):
         port = int(run_extra_options.pop("port", 8000))  # type: ignore[arg-type]
         workers = int(run_extra_options.pop("workers", 1))  # type: ignore[arg-type]
         host = str(run_extra_options.pop("host", "localhost"))
+        fd = int(run_extra_options.pop("fd", -1))  # type: ignore[arg-type]
         config = uvicorn.Config(
             self,
             host=host,
             port=port,
             log_level=log_level,
             workers=workers,
+            fd=fd if fd != -1 else None,
             **run_extra_options,
         )
         server = uvicorn.Server(config)


### PR DESCRIPTION
# Description

It is common to use a process manager like Supervisor. In such cases, we typically pass a file descriptor instead of binding to a host and port directly. Currently, it is possible to pass the value to `Uvicorn.Config` via `run_extra_options`, but it needs to be cast as an integer.

https://www.uvicorn.org/deployment/#supervisor

```sh
faststream run "path-to-app" --fd=0
```

## Type of change

Please delete options that are not relevant.

- [x] New feature (a non-breaking change that adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [x] I have included code examples to illustrate the modifications
