### PR TITLE
fix: change oauth type in asyncapi schema

### DIFF
--- a/faststream/security.py
+++ b/faststream/security.py
@@ -167,7 +167,7 @@ class SASLOAuthBearer(BaseSecurity):
 
     def get_schema(self) -> Dict[str, Dict[str, str]]:
         """Get the security schema for SASL/OAUTHBEARER authentication."""
-        return {"oauthbearer": {"type": "oauthBearer"}}
+        return {"oauthbearer": {"type": "oauth2", "$ref": ""}}
 
 
 class SASLGSSAPI(BaseSecurity):

--- a/tests/asyncapi/confluent/test_security.py
+++ b/tests/asyncapi/confluent/test_security.py
@@ -192,7 +192,7 @@ def test_oauthbearer_security_schema():
         {"oauthbearer": []}
     ]
     sasl_oauthbearer_security_schema["components"]["securitySchemes"] = {
-        "oauthbearer": {"type": "oauthBearer"}
+        "oauthbearer": {"type": "oauth2", "$ref": ""}
     }
 
     assert schema == sasl_oauthbearer_security_schema

--- a/tests/asyncapi/kafka/test_security.py
+++ b/tests/asyncapi/kafka/test_security.py
@@ -192,7 +192,7 @@ def test_oauthbearer_security_schema():
         {"oauthbearer": []}
     ]
     sasl_oauthbearer_security_schema["components"]["securitySchemes"] = {
-        "oauthbearer": {"type": "oauthBearer"}
+        "oauthbearer": {"type": "oauth2", "$ref": ""}
     }
 
     assert schema == sasl_oauthbearer_security_schema


### PR DESCRIPTION
# Description

Added changes to the generation of AsyncAPI documentation in the OAuthBearer part. According to the AsyncAPI specification, the OAuthBearer is mapped to oauth2. Also adds a “$ref” field for mapping and generating documentation. It should be clarified in the future whether requiring this field is a bug or whether additional edits are needed.

Thank you to the following developers for their help:
1) @Lancetnik for help with the bug and support during the fix;
2) @KrySeyt for consultations on AsyncAPI in FastStream;
3) @three-question-marks for spending time together while fixing this problem and studying AsyncAPI documentation at the same time;
4) @dalelane for help in mapping Kafka Security Config to AsyncAPI types

Fixes #1631

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [Х] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [Х] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [Х] I have conducted a self-review of my own code
- [] I have made the necessary changes to the documentation
- [Х] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [Х] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [Х] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
