### PR TITLE
fix: HandlerException ingored

### DIFF
--- a/faststream/prometheus/middleware.py
+++ b/faststream/prometheus/middleware.py
@@ -2,7 +2,7 @@ import time
 from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence
 
 from faststream import BaseMiddleware
-from faststream.exceptions import HandlerException
+from faststream.exceptions import IgnoredException
 from faststream.prometheus.consts import (
     PROCESSING_STATUS_BY_ACK_STATUS,
     PROCESSING_STATUS_BY_HANDLER_EXCEPTION_MAP,
@@ -73,7 +73,7 @@ class PrometheusMiddleware(BaseMiddleware):
         except Exception as e:
             err = e
 
-            if not isinstance(err, HandlerException):
+            if not isinstance(err, IgnoredException):
                 self._metrics_manager.add_received_processed_message_exception(
                     exception_type=type(err).__name__,
                     broker=messaging_system,

--- a/faststream/prometheus/middleware.py
+++ b/faststream/prometheus/middleware.py
@@ -2,6 +2,7 @@ import time
 from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence
 
 from faststream import BaseMiddleware
+from faststream.exceptions import HandlerException
 from faststream.prometheus.consts import (
     PROCESSING_STATUS_BY_ACK_STATUS,
     PROCESSING_STATUS_BY_HANDLER_EXCEPTION_MAP,
@@ -71,11 +72,13 @@ class PrometheusMiddleware(BaseMiddleware):
 
         except Exception as e:
             err = e
-            self._metrics_manager.add_received_processed_message_exception(
-                exception_type=type(err).__name__,
-                broker=messaging_system,
-                handler=destination_name,
-            )
+
+            if not isinstance(err, HandlerException):
+                self._metrics_manager.add_received_processed_message_exception(
+                    exception_type=type(err).__name__,
+                    broker=messaging_system,
+                    handler=destination_name,
+                )
             raise
 
         finally:

--- a/tests/prometheus/basic.py
+++ b/tests/prometheus/basic.py
@@ -7,7 +7,7 @@ from prometheus_client import CollectorRegistry
 
 from faststream import Context
 from faststream.broker.message import AckStatus
-from faststream.exceptions import RejectMessage
+from faststream.exceptions import HandlerException, RejectMessage
 from faststream.prometheus.middleware import (
     PROCESSING_STATUS_BY_ACK_STATUS,
     PROCESSING_STATUS_BY_HANDLER_EXCEPTION_MAP,
@@ -176,7 +176,7 @@ class LocalPrometheusTestcase(BaseTestcaseConfig):
             ),
         ]
 
-        if status == ProcessingStatus.error:
+        if exception_class and not issubclass(exception_class, HandlerException):
             assert (
                 metrics_manager.add_received_processed_message_exception.mock_calls
                 == [

--- a/tests/prometheus/basic.py
+++ b/tests/prometheus/basic.py
@@ -193,7 +193,10 @@ class LocalPrometheusTestcase(BaseTestcaseConfig):
                 ]
             )
         else:
-            assert metrics_manager.add_received_processed_message_exception.mock_calls == []
+            assert (
+                metrics_manager.add_received_processed_message_exception.mock_calls
+                == []
+            )
 
     def assert_publish_metrics(self, metrics_manager: Any):
         settings_provider = self.settings_provider_factory(None)


### PR DESCRIPTION
# Description

In the current version of FastStream, if I `raise AckMessage` (or any `HandlerException`) when processing a message, then the following line will be added to the error metric:

```
faststream_received_processed_messages_exceptions_total{app_name="faststream",broker="rabbitmq",exception_type="AckMessage",handler="default.queue"} 1.0
```

It shouldn't be like this, because `HandlerException`s are not user-defined exceptions and should not increase the error metric when they are thrown

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [x] I have included code examples to illustrate the modifications
