### PR TITLE
fix: RabbitBroker's ping is more objective

### DIFF
--- a/faststream/rabbit/broker/broker.py
+++ b/faststream/rabbit/broker/broker.py
@@ -839,7 +839,7 @@ class RabbitBroker(
                 if cancel_scope.cancel_called:
                     return False
 
-                if not self._connection.is_closed:
+                if self._connection.connected.is_set():
                     return True
 
                 await anyio.sleep(sleep_time)


### PR DESCRIPTION
# Description

I have a situation where RabbitMQ is up, a service is up with a successful connection to RabbitMQ, I stop it, a reconnection occurs to it every n seconds.

in fact there is no connection, my /readiness handle returns 204, although the service is not readiness.

the ping method checks the connection's `is_closed` flag, although this is not entirely correct, because it will be `True` only when `close`/`__del__`/`__aexit__` is called on the connection

checking the `connected` attribute of the `connection` object will be more objective: `True` when there is a connection, `False` when there is not (there was no connection right away, or a reconnection occurs)


## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [x] I have included code examples to illustrate the modifications
