### PR TITLE
chore: pin typer version, bump FastStream

### DIFF
--- a/faststream/__about__.py
+++ b/faststream/__about__.py
@@ -1,5 +1,5 @@
 """Simple and fast framework to create message brokers based microservices."""
 
-__version__ = "0.5.30"
+__version__ = "0.5.31"
 
 SERVICE_NAME = f"faststream-{__version__}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ redis = ["redis>=5.0.0,<6.0.0"]
 otel = ["opentelemetry-sdk>=1.24.0,<2.0.0"]
 
 cli = [
-    "typer>=0.9,!=0.12,<1",
+    "typer>=0.9,!=0.12,<=0.14",
     "watchfiles>=0.15.0,<0.25.0"
 ]
 


### PR DESCRIPTION
Typer is extremely unstable for now and I would like to strict its' version to prevent `faststream[cli]==latest` from broken
I think, weekly update by dependantbot should be enough to stay actual