### PR TITLE
docs: use DeliverPolicy Enum for deliver_policy in subscriber

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -153,7 +153,7 @@
         "filename": "docs/docs/en/release.md",
         "hashed_secret": "35675e68f4b5af7b995d9205ad0fc43842f16450",
         "is_verified": false,
-        "line_number": 1850,
+        "line_number": 1898,
         "is_secret": false
       }
     ],
@@ -178,5 +178,5 @@
       }
     ]
   },
-  "generated_at": "2024-11-15T07:38:53Z"
+  "generated_at": "2024-12-01T18:17:03Z"
 }

--- a/docs/docs_src/nats/js/main.py
+++ b/docs/docs_src/nats/js/main.py
@@ -1,5 +1,6 @@
 from faststream import FastStream, Logger
 from faststream.nats import JStream, NatsBroker
+from nats.js.api import DeliverPolicy
 
 broker = NatsBroker()
 app = FastStream(broker)
@@ -9,7 +10,7 @@ stream = JStream(name="stream")
 @broker.subscriber(
     "js-subject",
     stream=stream,
-    deliver_policy="new",
+    deliver_policy=DeliverPolicy.NEW,
 )
 async def handler(msg: str, logger: Logger):
     logger.info(msg)


### PR DESCRIPTION
Updated deliver_policy to use DeliverPolicy enum according to type definition

# Description

Updated deliver_policy to use DeliverPolicy enum according to type definition

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [ ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
