### PR TITLE
feat: add application states

### DIFF
--- a/faststream/_internal/application.py
+++ b/faststream/_internal/application.py
@@ -16,7 +16,11 @@ from typing_extensions import ParamSpec
 from faststream._internal.constants import EMPTY
 from faststream._internal.context import ContextRepo
 from faststream._internal.log import logger
-from faststream._internal.state import DIState
+from faststream._internal.state import (
+    BasicApplicationState,
+    DIState,
+    RunningApplicationState,
+)
 from faststream._internal.state.broker import OuterBrokerState
 from faststream._internal.utils import apply_types
 from faststream._internal.utils.functions import (
@@ -99,13 +103,15 @@ class StartAbleApplication:
 
             serializer = PydanticSerializer()
 
-        self._state = DIState(
-            use_fastdepends=True,
-            get_dependent=None,
-            call_decorators=(),
-            serializer=serializer,
-            provider=self.provider,
-            context=self.context,
+        self._state = BasicApplicationState(
+            di_state=DIState(
+                use_fastdepends=True,
+                get_dependent=None,
+                call_decorators=(),
+                serializer=serializer,
+                provider=self.provider,
+                context=self.context,
+            )
         )
 
         self.broker = broker
@@ -113,7 +119,7 @@ class StartAbleApplication:
         self._setup()
 
     def _setup(self) -> None:
-        self.broker._setup(OuterBrokerState(di_state=self._state))
+        self.broker._setup(OuterBrokerState(di_state=self._state.di_state))
 
     async def _start_broker(self) -> None:
         await self.broker.start()
@@ -188,6 +194,8 @@ class Application(StartAbleApplication):
         async with self._startup_logging(log_level=log_level):
             await self.start(**(run_extra_options or {}))
 
+        self._state = RunningApplicationState(di_state=self._state.di_state)
+
     async def start(
         self,
         **run_extra_options: "SettingField",
@@ -234,6 +242,8 @@ class Application(StartAbleApplication):
         """Private method calls `stop` with logging."""
         async with self._shutdown_logging(log_level=log_level):
             await self.stop()
+
+        self._state = BasicApplicationState(di_state=self._state.di_state)
 
     async def stop(self) -> None:
         """Executes shutdown hooks and stop broker."""
@@ -318,3 +328,7 @@ class Application(StartAbleApplication):
             apply_types(to_async(func), context__=self.context)
         )
         return func
+
+    @property
+    def running(self) -> bool:
+        return self._state.running

--- a/faststream/_internal/state/__init__.py
+++ b/faststream/_internal/state/__init__.py
@@ -1,3 +1,4 @@
+from .application import BasicApplicationState, RunningApplicationState
 from .broker import BrokerState, EmptyBrokerState
 from .fast_depends import DIState
 from .logger import LoggerParamsStorage, LoggerState
@@ -6,6 +7,8 @@ from .proto import SetupAble
 
 __all__ = (
     # state
+    "BasicApplicationState",
+    "RunningApplicationState",
     "BrokerState",
     # FastDepend
     "DIState",

--- a/faststream/_internal/state/__init__.py
+++ b/faststream/_internal/state/__init__.py
@@ -8,7 +8,6 @@ from .proto import SetupAble
 __all__ = (
     # state
     "BasicApplicationState",
-    "RunningApplicationState",
     "BrokerState",
     # FastDepend
     "DIState",
@@ -17,6 +16,7 @@ __all__ = (
     # logging
     "LoggerState",
     "Pointer",
+    "RunningApplicationState",
     # proto
     "SetupAble",
 )

--- a/faststream/_internal/state/application.py
+++ b/faststream/_internal/state/application.py
@@ -1,0 +1,28 @@
+from abc import ABC, abstractmethod
+
+from faststream._internal.state.fast_depends import DIState
+
+
+class ApplicationState(ABC):
+    def __init__(self, di_state: DIState) -> None:
+        self._di_state = di_state
+
+    @property
+    @abstractmethod
+    def running(self) -> bool: ...
+
+    @property
+    def di_state(self) -> DIState:
+        return self._di_state
+
+
+class BasicApplicationState(ApplicationState):
+    @property
+    def running(self) -> bool:
+        return False
+
+
+class RunningApplicationState(ApplicationState):
+    @property
+    def running(self) -> bool:
+        return True

--- a/tests/cli/test_app_state.py
+++ b/tests/cli/test_app_state.py
@@ -1,0 +1,31 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from faststream import FastStream
+
+
+@pytest.mark.asyncio()
+async def test_state_running(app: FastStream) -> None:
+    with patch(
+        "faststream._internal.application.Application.start", new_callable=AsyncMock
+    ):
+        await app._startup()
+
+        assert app.running
+
+
+@pytest.mark.asyncio()
+async def test_state_stopped(app: FastStream) -> None:
+    with (
+        patch(
+            "faststream._internal.application.Application.start", new_callable=AsyncMock
+        ),
+        patch(
+            "faststream._internal.application.Application.stop", new_callable=AsyncMock
+        ),
+    ):
+        await app._startup()
+        await app._shutdown()
+
+        assert not app.running


### PR DESCRIPTION
# Description

Hello. While writing the test for launching the application, I encountered the need to check the application's active state. I suggest adding two states for the application: "stopped" and "running".

## Type of change

Please delete options that are not relevant.

- [ ] New feature (a non-breaking change that adds functionality)

## Checklist

- [ ] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [ ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
