### PR TITLE
Update aio-pika external docs URL as it has been moved

### DIFF
--- a/docs/docs/en/rabbit/index.md
+++ b/docs/docs/en/rabbit/index.md
@@ -11,7 +11,7 @@ search:
 # Rabbit Routing
 
 !!! note ""
-      **FastStream** *RabbitMQ* support is implemented on top of [**aio-pika**](https://aio-pika.readthedocs.io/en/latest/){.external-link target="_blank"}. You can always get access to objects of it, if you need to use some low-level methods, not represented in **FastStream**.
+      **FastStream** *RabbitMQ* support is implemented on top of [**aio-pika**](https://docs.aio-pika.com/){.external-link target="_blank"}. You can always get access to objects of it, if you need to use some low-level methods, not represented in **FastStream**.
 
 ## Advantages
 


### PR DESCRIPTION
# Description
https://aio-pika.readthedocs.io/ currently returns 404 Project not found and it appears the documentation is now hosted at https://docs.aio-pika.com/

## Type of change


- [X] Documentation (typos, code examples, or any documentation updates)


## Checklist

- [ ] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [ ] I have conducted a self-review of my own code
- [X] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
