### PR TITLE
Remove reference of "faststream.access" from docs

### DIFF
--- a/docs/docs/en/getting-started/logging.md
+++ b/docs/docs/en/getting-started/logging.md
@@ -10,11 +10,6 @@ search:
 
 # Application and Access Logging
 
-**FastStream** uses two already configured loggers:
-
-* `faststream` - used by `FastStream` app
-* `faststream.access` - used by the broker
-
 ## Logging Requests
 
 To log requests, it is strongly recommended to use the `access_logger` of your broker, as it is available from the [Context](../getting-started/context/existed.md){.internal-link} of your application.
@@ -75,22 +70,6 @@ If you are not satisfied with the current format of your application logs, you c
 ```python
 from faststream.rabbit import RabbitBroker
 broker = RabbitBroker(log_fmt="%(asctime)s %(levelname)s - %(message)s")
-```
-
-## Logger Access
-
-If you want to override default logger's behavior, you can access them directly via `logging`.
-
-```python
-import logging
-logger = logging.getLogger("faststream")
-access_logger = logging.getLogger("faststream.access")
-```
-
-Or you can import them from **FastStream**.
-
-```python
-from faststream.log import access_logger, logger
 ```
 
 ## Using Your Own Loggers


### PR DESCRIPTION
# Description
`faststream.access` is not the correct way of configuring faststream's loggers. So remove their reference from docs.

Also the import `from faststream.log import access_logger` is not valid.

Fixes #1994

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples, or any documentation updates)
- [x] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [x] I have included code examples to illustrate the modifications
