### PR TITLE
feat: add static instrumentation info

### DIFF
--- a/faststream/opentelemetry/consts.py
+++ b/faststream/opentelemetry/consts.py
@@ -1,3 +1,6 @@
+from faststream.__about__ import __version__
+
+
 class MessageAction:
     CREATE = "create"
     PUBLISH = "publish"
@@ -9,3 +12,5 @@ OTEL_SCHEMA = "https://opentelemetry.io/schemas/1.11.0"
 ERROR_TYPE = "error.type"
 MESSAGING_DESTINATION_PUBLISH_NAME = "messaging.destination_publish.name"
 WITH_BATCH = "with_batch"
+INSTRUMENTING_MODULE_NAME = "opentelemetry.instrumentation.faststream"
+INSTRUMENTING_LIBRARY_VERSION = __version__

--- a/faststream/opentelemetry/middleware.py
+++ b/faststream/opentelemetry/middleware.py
@@ -15,6 +15,8 @@ from faststream import context as fs_context
 from faststream.opentelemetry.baggage import Baggage
 from faststream.opentelemetry.consts import (
     ERROR_TYPE,
+    INSTRUMENTING_LIBRARY_VERSION,
+    INSTRUMENTING_MODULE_NAME,
     MESSAGING_DESTINATION_PUBLISH_NAME,
     OTEL_SCHEMA,
     WITH_BATCH,
@@ -330,7 +332,8 @@ def _get_meter(
 
 def _get_tracer(tracer_provider: Optional["TracerProvider"] = None) -> "Tracer":
     return trace.get_tracer(
-        __name__,
+        instrumenting_module_name=INSTRUMENTING_MODULE_NAME,
+        instrumenting_library_version=INSTRUMENTING_LIBRARY_VERSION,
         tracer_provider=tracer_provider,
         schema_url=OTEL_SCHEMA,
     )


### PR DESCRIPTION
# Description

Add `instrumenting_module_name` and `instrumenting_library_version` for correct display of information about the    **OpenTelemetry** instrumentation.

Fixes #1993

## Type of change

- [x] New feature (a non-breaking change that adds functionality)


## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] My changes do not generate any new warnings
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
