### PR TITLE
fix: KeyError 'reply_to' in rabbit

### DIFF
--- a/faststream/rabbit/publisher/usecase.py
+++ b/faststream/rabbit/publisher/usecase.py
@@ -72,7 +72,7 @@ class LogicPublisher(PublisherUsecase[IncomingMessage]):
 
         request_options = dict(message_kwargs)
         self.headers = request_options.pop("headers") or {}
-        self.reply_to = request_options.pop("reply_to", "")
+        self.reply_to = request_options.pop("reply_to", None) or ""
         self.timeout = request_options.pop("timeout", None)
 
         message_options, _ = filter_by_dict(MessageOptions, request_options)

--- a/faststream/rabbit/response.py
+++ b/faststream/rabbit/response.py
@@ -75,7 +75,7 @@ class RabbitPublishCommand(PublishCommand):
         **message_options: Unpack["MessageOptions"],
     ) -> None:
         headers = message_options.pop("headers", {})
-        reply_to = message_options.pop("reply_to") or ""
+        reply_to = message_options.pop("reply_to", None) or ""
         correlation_id = message_options.pop("correlation_id", None)
 
         super().__init__(


### PR DESCRIPTION
# Description

Fixed bug in tests related to getting `reply_to` key in message options rebbit

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [X] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [X] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [X] I have conducted a self-review of my own code
- [X] I have made the necessary changes to the documentation
- [X] My changes do not generate any new warnings
- [X] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
