### PR TITLE
feat: Pretty prom tests

### DIFF
--- a/faststream/confluent/response.py
+++ b/faststream/confluent/response.py
@@ -109,7 +109,7 @@ class KafkaPublishCommand(PublishCommand):
             if body is None:
                 body = EMPTY
 
-            if isinstance(body, Sequence) and not isinstance(body, str):
+            if isinstance(body, Sequence) and not isinstance(body, (str, bytes)):
                 if body:
                     body, extra_bodies = body[0], body[1:]
                 else:

--- a/faststream/kafka/response.py
+++ b/faststream/kafka/response.py
@@ -101,7 +101,7 @@ class KafkaPublishCommand(PublishCommand):
             if body is None:
                 body = EMPTY
 
-            if isinstance(body, Sequence) and not isinstance(body, str):
+            if isinstance(body, Sequence) and not isinstance(body, (str, bytes)):
                 if body:
                     body, extra_bodies = body[0], body[1:]
                 else:

--- a/faststream/redis/response.py
+++ b/faststream/redis/response.py
@@ -130,7 +130,7 @@ class RedisPublishCommand(PublishCommand):
             if body is None:
                 body = EMPTY
 
-            if isinstance(body, Sequence) and not isinstance(body, str):
+            if isinstance(body, Sequence) and not isinstance(body, (str, bytes)):
                 if body:
                     body, extra_bodies = body[0], body[1:]
                 else:

--- a/faststream/response/response.py
+++ b/faststream/response/response.py
@@ -52,7 +52,7 @@ class PublishCommand(Response):
 
     @property
     def batch_bodies(self) -> tuple["Any", ...]:
-        if self.body:
+        if self.body or isinstance(self.body, (str, bytes)):
             return (self.body,)
         return ()
 

--- a/tests/brokers/confluent/test_publish_command.py
+++ b/tests/brokers/confluent/test_publish_command.py
@@ -34,6 +34,8 @@ def test_kafka_response_class():
         pytest.param(None, (), id="None Response"),
         pytest.param((), (), id="Empty Sequence"),
         pytest.param("123", ("123",), id="String Response"),
+        pytest.param("", ("",), id="Empty String Response"),
+        pytest.param(b"", (b"",), id="Empty Bytes Response"),
         pytest.param([1, 2, 3], (1, 2, 3), id="Sequence Data"),
         pytest.param([0, 1, 2], (0, 1, 2), id="Sequence Data with False first element"),
     ),

--- a/tests/brokers/kafka/test_publish_command.py
+++ b/tests/brokers/kafka/test_publish_command.py
@@ -34,6 +34,8 @@ def test_kafka_response_class():
         pytest.param(None, (), id="None Response"),
         pytest.param((), (), id="Empty Sequence"),
         pytest.param("123", ("123",), id="String Response"),
+        pytest.param("", ("",), id="Empty String Response"),
+        pytest.param(b"", (b"",), id="Empty Bytes Response"),
         pytest.param([1, 2, 3], (1, 2, 3), id="Sequence Data"),
         pytest.param([0, 1, 2], (0, 1, 2), id="Sequence Data with False first element"),
     ),

--- a/tests/brokers/redis/test_publish_command.py
+++ b/tests/brokers/redis/test_publish_command.py
@@ -34,6 +34,8 @@ def test_kafka_response_class() -> None:
         pytest.param(None, (), id="None Response"),
         pytest.param((), (), id="Empty Sequence"),
         pytest.param("123", ("123",), id="String Response"),
+        pytest.param("", ("",), id="Empty String Response"),
+        pytest.param(b"", (b"",), id="Empty Bytes Response"),
         pytest.param([1, 2, 3], (1, 2, 3), id="Sequence Data"),
         pytest.param([0, 1, 2], (0, 1, 2), id="Sequence Data with False first element"),
     ),

--- a/tests/prometheus/basic.py
+++ b/tests/prometheus/basic.py
@@ -1,8 +1,8 @@
 import asyncio
-from typing import Any, Optional
-from unittest.mock import ANY, Mock, call
+from typing import Any, Optional, cast
 
 import pytest
+from dirty_equals import IsList, IsPositiveFloat, IsStr
 from prometheus_client import CollectorRegistry
 
 from faststream import Context
@@ -14,27 +14,28 @@ from faststream.prometheus.middleware import (
     PROCESSING_STATUS_BY_HANDLER_EXCEPTION_MAP,
     BasePrometheusMiddleware,
 )
-from faststream.prometheus.types import ProcessingStatus
+from faststream.prometheus.types import ProcessingStatus, PublishingStatus
 from tests.brokers.base.basic import BaseTestcaseConfig
+from tests.prometheus.utils import (
+    get_published_messages_duration_seconds_metric,
+    get_published_messages_exceptions_metric,
+    get_published_messages_metric,
+    get_received_messages_in_process_metric,
+    get_received_messages_metric,
+    get_received_messages_size_bytes_metric,
+    get_received_processed_messages_duration_seconds_metric,
+    get_received_processed_messages_exceptions_metric,
+    get_received_processed_messages_metric,
+)
 
 
 @pytest.mark.asyncio()
 class LocalPrometheusTestcase(BaseTestcaseConfig):
-    def get_broker(self, apply_types: bool = False, **kwargs: Any):
-        raise NotImplementedError
-
     def get_middleware(self, **kwargs: Any) -> BasePrometheusMiddleware:
         raise NotImplementedError
 
-    @staticmethod
-    def consume_destination_name(queue: str) -> str:
-        return queue
-
-    @property
-    def settings_provider_factory(self):
-        return self.get_middleware(
-            registry=CollectorRegistry()
-        )._settings_provider_factory
+    def get_settings_provider(self) -> MetricsSettingsProvider[Any]:
+        raise NotImplementedError
 
     @pytest.mark.parametrize(
         (
@@ -81,10 +82,8 @@ class LocalPrometheusTestcase(BaseTestcaseConfig):
         exception_class: Optional[type[Exception]],
     ) -> None:
         event = asyncio.Event()
-
-        middleware = self.get_middleware(registry=CollectorRegistry())
-        metrics_manager_mock = Mock()
-        middleware._metrics_manager = metrics_manager_mock
+        registry = CollectorRegistry()
+        middleware = self.get_middleware(registry=registry)
 
         broker = self.get_broker(apply_types=True, middlewares=(middleware,))
 
@@ -118,62 +117,69 @@ class LocalPrometheusTestcase(BaseTestcaseConfig):
             await asyncio.wait(tasks, timeout=self.timeout)
 
         assert event.is_set()
-        self.assert_consume_metrics(
-            metrics_manager=metrics_manager_mock,
+        self.assert_metrics(
+            registry=registry,
             message=message,
             exception_class=exception_class,
         )
-        self.assert_publish_metrics(metrics_manager=metrics_manager_mock)
 
-    def assert_consume_metrics(
+    def assert_metrics(
         self,
         *,
-        metrics_manager: Any,
+        registry: CollectorRegistry,
         message: Any,
         exception_class: Optional[type[Exception]],
     ) -> None:
-        settings_provider = self.settings_provider_factory(message.raw_message)
+        settings_provider = self.get_settings_provider()
         consume_attrs = settings_provider.get_consume_attrs_from_message(message)
-        assert metrics_manager.add_received_message.mock_calls == [
-            call(
-                amount=consume_attrs["messages_count"],
-                broker=settings_provider.messaging_system,
-                handler=consume_attrs["destination_name"],
-            ),
-        ]
 
-        assert metrics_manager.observe_received_messages_size.mock_calls == [
-            call(
-                size=consume_attrs["message_size"],
-                broker=settings_provider.messaging_system,
-                handler=consume_attrs["destination_name"],
-            ),
-        ]
+        received_messages_metric = get_received_messages_metric(
+            metrics_prefix="faststream",
+            app_name="faststream",
+            broker=settings_provider.messaging_system,
+            queue=consume_attrs["destination_name"],
+            messages_amount=consume_attrs["messages_count"],
+        )
 
-        assert metrics_manager.add_received_message_in_process.mock_calls == [
-            call(
-                amount=consume_attrs["messages_count"],
-                broker=settings_provider.messaging_system,
-                handler=consume_attrs["destination_name"],
+        received_messages_size_bytes_metric = get_received_messages_size_bytes_metric(
+            metrics_prefix="faststream",
+            app_name="faststream",
+            broker=settings_provider.messaging_system,
+            queue=consume_attrs["destination_name"],
+            buckets=(
+                2.0**4,
+                2.0**6,
+                2.0**8,
+                2.0**10,
+                2.0**12,
+                2.0**14,
+                2.0**16,
+                2.0**18,
+                2.0**20,
+                2.0**22,
+                2.0**24,
+                float("inf"),
             ),
-        ]
-        assert metrics_manager.remove_received_message_in_process.mock_calls == [
-            call(
-                amount=consume_attrs["messages_count"],
+            size=consume_attrs["message_size"],
+            messages_amount=1,
+        )
+
+        received_messages_in_process_metric = get_received_messages_in_process_metric(
+            metrics_prefix="faststream",
+            app_name="faststream",
+            broker=settings_provider.messaging_system,
+            queue=consume_attrs["destination_name"],
+            messages_amount=0,
+        )
+
+        received_processed_messages_duration_seconds_metric = (
+            get_received_processed_messages_duration_seconds_metric(
+                metrics_prefix="faststream",
+                app_name="faststream",
                 broker=settings_provider.messaging_system,
-                handler=consume_attrs["destination_name"],
+                queue=consume_attrs["destination_name"],
+                duration=cast(float, IsPositiveFloat),
             )
-        ]
-
-        assert (
-            metrics_manager.observe_received_processed_message_duration.mock_calls
-            == [
-                call(
-                    duration=ANY,
-                    broker=settings_provider.messaging_system,
-                    handler=consume_attrs["destination_name"],
-                ),
-            ]
         )
 
         status = ProcessingStatus.acked
@@ -186,47 +192,73 @@ class LocalPrometheusTestcase(BaseTestcaseConfig):
         elif message.committed:
             status = PROCESSING_STATUS_BY_ACK_STATUS[message.committed]
 
-        assert metrics_manager.add_received_processed_message.mock_calls == [
-            call(
-                amount=consume_attrs["messages_count"],
-                broker=settings_provider.messaging_system,
-                handler=consume_attrs["destination_name"],
-                status=status.value,
-            ),
-        ]
+        received_processed_messages_metric = get_received_processed_messages_metric(
+            metrics_prefix="faststream",
+            app_name="faststream",
+            broker=settings_provider.messaging_system,
+            queue=consume_attrs["destination_name"],
+            messages_amount=consume_attrs["messages_count"],
+            status=status,
+        )
+
+        exception_type: Optional[str] = None
 
         if exception_class and not issubclass(exception_class, IgnoredException):
-            assert (
-                metrics_manager.add_received_processed_message_exception.mock_calls
-                == [
-                    call(
-                        broker=settings_provider.messaging_system,
-                        handler=consume_attrs["destination_name"],
-                        exception_type=exception_class.__name__,
-                    ),
-                ]
-            )
-        else:
-            assert (
-                metrics_manager.add_received_processed_message_exception.mock_calls
-                == []
-            )
+            exception_type = exception_class.__name__
 
-    def assert_publish_metrics(self, metrics_manager: Any) -> None:
-        settings_provider = self.settings_provider_factory(None)
-        assert metrics_manager.observe_published_message_duration.mock_calls == [
-            call(
-                duration=ANY, broker=settings_provider.messaging_system, destination=ANY
-            ),
-        ]
-        assert metrics_manager.add_published_message.mock_calls == [
-            call(
-                amount=ANY,
+        received_processed_messages_exceptions_metric = (
+            get_received_processed_messages_exceptions_metric(
+                metrics_prefix="faststream",
+                app_name="faststream",
                 broker=settings_provider.messaging_system,
-                destination=ANY,
-                status="success",
-            ),
-        ]
+                queue=consume_attrs["destination_name"],
+                exception_type=exception_type,
+                exceptions_amount=consume_attrs["messages_count"],
+            )
+        )
+
+        published_messages_metric = get_published_messages_metric(
+            metrics_prefix="faststream",
+            app_name="faststream",
+            broker=settings_provider.messaging_system,
+            queue=cast(str, IsStr),
+            status=PublishingStatus.success,
+            messages_amount=consume_attrs["messages_count"],
+        )
+
+        published_messages_duration_seconds_metric = (
+            get_published_messages_duration_seconds_metric(
+                metrics_prefix="faststream",
+                app_name="faststream",
+                broker=settings_provider.messaging_system,
+                queue=cast(str, IsStr),
+                duration=cast(float, IsPositiveFloat),
+            )
+        )
+
+        published_messages_exceptions_metric = get_published_messages_exceptions_metric(
+            metrics_prefix="faststream",
+            app_name="faststream",
+            broker=settings_provider.messaging_system,
+            queue=cast(str, IsStr),
+            exception_type=None,
+        )
+
+        expected_metrics = IsList(
+            received_messages_metric,
+            received_messages_size_bytes_metric,
+            received_messages_in_process_metric,
+            received_processed_messages_metric,
+            received_processed_messages_duration_seconds_metric,
+            received_processed_messages_exceptions_metric,
+            published_messages_metric,
+            published_messages_duration_seconds_metric,
+            published_messages_exceptions_metric,
+            check_order=False,
+        )
+        real_metrics = list(registry.collect())
+
+        assert real_metrics == expected_metrics
 
 
 class LocalRPCPrometheusTestcase:
@@ -236,16 +268,21 @@ class LocalRPCPrometheusTestcase:
         queue: str,
     ) -> None:
         event = asyncio.Event()
+        registry = CollectorRegistry()
 
-        middleware = self.get_middleware(registry=CollectorRegistry())
-        metrics_manager_mock = Mock()
-        middleware._metrics_manager = metrics_manager_mock
+        middleware = self.get_middleware(registry=registry)
 
         broker = self.get_broker(apply_types=True, middlewares=(middleware,))
 
+        message = None
+
         @broker.subscriber(queue)
-        async def handle():
+        async def handle(m=Context("message")):
             event.set()
+
+            nonlocal message
+            message = m
+
             return ""
 
         async with self.patch_broker(broker) as br:
@@ -257,8 +294,12 @@ class LocalRPCPrometheusTestcase:
             )
 
         assert event.is_set()
-        metrics_manager_mock.add_received_message.assert_called_once()
-        metrics_manager_mock.add_published_message.assert_called_once()
+
+        self.assert_metrics(
+            registry=registry,
+            message=message,
+            exception_class=None,
+        )
 
 
 class LocalMetricsSettingsProviderTestcase:
@@ -268,11 +309,11 @@ class LocalMetricsSettingsProviderTestcase:
         raise NotImplementedError
 
     @staticmethod
-    def get_provider() -> MetricsSettingsProvider:
+    def get_settings_provider() -> MetricsSettingsProvider:
         raise NotImplementedError
 
     def test_messaging_system(self) -> None:
-        provider = self.get_provider()
+        provider = self.get_settings_provider()
         assert provider.messaging_system == self.messaging_system
 
     def test_one_registry_for_some_middlewares(self) -> None:

--- a/tests/prometheus/confluent/basic.py
+++ b/tests/prometheus/confluent/basic.py
@@ -2,10 +2,14 @@ from typing import Any
 
 from faststream import AckPolicy
 from faststream.confluent.prometheus import KafkaPrometheusMiddleware
+from faststream.confluent.prometheus.provider import (
+    BatchConfluentMetricsSettingsProvider,
+    ConfluentMetricsSettingsProvider,
+)
 from tests.brokers.confluent.basic import ConfluentTestcaseConfig
 
 
-class KafkaPrometheusSettings(ConfluentTestcaseConfig):
+class BaseConfluentPrometheusSettings(ConfluentTestcaseConfig):
     messaging_system = "kafka"
 
     def get_middleware(self, **kwargs: Any) -> KafkaPrometheusMiddleware:
@@ -26,3 +30,13 @@ class KafkaPrometheusSettings(ConfluentTestcaseConfig):
             "ack_policy": AckPolicy.REJECT_ON_ERROR,
             **kwargs,
         }
+
+
+class ConfluentPrometheusSettings(BaseConfluentPrometheusSettings):
+    def get_settings_provider(self) -> ConfluentMetricsSettingsProvider:
+        return ConfluentMetricsSettingsProvider()
+
+
+class BatchConfluentPrometheusSettings(BaseConfluentPrometheusSettings):
+    def get_settings_provider(self) -> BatchConfluentMetricsSettingsProvider:
+        return BatchConfluentMetricsSettingsProvider()

--- a/tests/prometheus/confluent/test_confluent.py
+++ b/tests/prometheus/confluent/test_confluent.py
@@ -1,6 +1,5 @@
 import asyncio
 from typing import Any
-from unittest.mock import Mock
 
 import pytest
 from prometheus_client import CollectorRegistry
@@ -12,20 +11,19 @@ from tests.brokers.confluent.test_consume import TestConsume
 from tests.brokers.confluent.test_publish import TestPublish
 from tests.prometheus.basic import LocalPrometheusTestcase
 
-from .basic import KafkaPrometheusSettings
+from .basic import BatchConfluentPrometheusSettings, ConfluentPrometheusSettings
 
 
 @pytest.mark.confluent()
-class TestPrometheus(KafkaPrometheusSettings, LocalPrometheusTestcase):
-    async def test_metrics_batch(
+class TestBatchPrometheus(BatchConfluentPrometheusSettings, LocalPrometheusTestcase):
+    async def test_metrics(
         self,
         queue: str,
     ):
         event = asyncio.Event()
 
-        middleware = self.get_middleware(registry=CollectorRegistry())
-        metrics_manager_mock = Mock()
-        middleware._metrics_manager = metrics_manager_mock
+        registry = CollectorRegistry()
+        middleware = self.get_middleware(registry=registry)
 
         broker = self.get_broker(apply_types=True, middlewares=(middleware,))
 
@@ -50,10 +48,15 @@ class TestPrometheus(KafkaPrometheusSettings, LocalPrometheusTestcase):
             await asyncio.wait(tasks, timeout=self.timeout)
 
         assert event.is_set()
-        self.assert_consume_metrics(
-            metrics_manager=metrics_manager_mock, message=message, exception_class=None
+        self.assert_metrics(
+            registry=registry,
+            message=message,
+            exception_class=None,
         )
-        self.assert_publish_metrics(metrics_manager=metrics_manager_mock)
+
+
+@pytest.mark.confluent()
+class TestPrometheus(ConfluentPrometheusSettings, LocalPrometheusTestcase): ...
 
 
 @pytest.mark.confluent()

--- a/tests/prometheus/kafka/basic.py
+++ b/tests/prometheus/kafka/basic.py
@@ -2,10 +2,14 @@ from typing import Any
 
 from faststream import AckPolicy
 from faststream.kafka.prometheus import KafkaPrometheusMiddleware
+from faststream.kafka.prometheus.provider import (
+    BatchKafkaMetricsSettingsProvider,
+    KafkaMetricsSettingsProvider,
+)
 from tests.brokers.kafka.basic import KafkaTestcaseConfig
 
 
-class KafkaPrometheusSettings(KafkaTestcaseConfig):
+class BaseKafkaPrometheusSettings(KafkaTestcaseConfig):
     messaging_system = "kafka"
 
     def get_middleware(self, **kwargs: Any) -> KafkaPrometheusMiddleware:
@@ -25,3 +29,13 @@ class KafkaPrometheusSettings(KafkaTestcaseConfig):
             "ack_policy": AckPolicy.REJECT_ON_ERROR,
             **kwargs,
         }
+
+
+class KafkaPrometheusSettings(BaseKafkaPrometheusSettings):
+    def get_settings_provider(self) -> KafkaMetricsSettingsProvider:
+        return KafkaMetricsSettingsProvider()
+
+
+class BatchKafkaPrometheusSettings(BaseKafkaPrometheusSettings):
+    def get_settings_provider(self) -> BatchKafkaMetricsSettingsProvider:
+        return BatchKafkaMetricsSettingsProvider()

--- a/tests/prometheus/kafka/test_provider.py
+++ b/tests/prometheus/kafka/test_provider.py
@@ -8,19 +8,17 @@ from faststream.kafka.prometheus.provider import (
     KafkaMetricsSettingsProvider,
     settings_provider_factory,
 )
-from faststream.prometheus import MetricsSettingsProvider
 from tests.prometheus.basic import LocalMetricsSettingsProviderTestcase
 
-from .basic import KafkaPrometheusSettings
+from .basic import BatchKafkaPrometheusSettings, KafkaPrometheusSettings
 
 
 class LocalBaseKafkaMetricsSettingsProviderTestcase(
-    KafkaPrometheusSettings,
     LocalMetricsSettingsProviderTestcase,
 ):
     def test_get_publish_destination_name_from_cmd(self, queue: str) -> None:
         expected_destination_name = queue
-        provider = self.get_provider()
+        provider = self.get_settings_provider()
         command = SimpleNamespace(destination=queue)
 
         destination_name = provider.get_publish_destination_name_from_cmd(command)
@@ -28,11 +26,9 @@ class LocalBaseKafkaMetricsSettingsProviderTestcase(
         assert destination_name == expected_destination_name
 
 
-class TestKafkaMetricsSettingsProvider(LocalBaseKafkaMetricsSettingsProviderTestcase):
-    @staticmethod
-    def get_provider() -> MetricsSettingsProvider:
-        return KafkaMetricsSettingsProvider()
-
+class TestKafkaMetricsSettingsProvider(
+    KafkaPrometheusSettings, LocalBaseKafkaMetricsSettingsProviderTestcase
+):
     def test_get_consume_attrs_from_message(self, queue: str) -> None:
         body = b"Hello"
         expected_attrs = {
@@ -43,19 +39,15 @@ class TestKafkaMetricsSettingsProvider(LocalBaseKafkaMetricsSettingsProviderTest
 
         message = SimpleNamespace(body=body, raw_message=SimpleNamespace(topic=queue))
 
-        provider = self.get_provider()
+        provider = self.get_settings_provider()
         attrs = provider.get_consume_attrs_from_message(message)
 
         assert attrs == expected_attrs
 
 
 class TestBatchKafkaMetricsSettingsProvider(
-    LocalBaseKafkaMetricsSettingsProviderTestcase
+    BatchKafkaPrometheusSettings, LocalBaseKafkaMetricsSettingsProviderTestcase
 ):
-    @staticmethod
-    def get_provider() -> MetricsSettingsProvider:
-        return BatchKafkaMetricsSettingsProvider()
-
     def test_get_consume_attrs_from_message(self, queue: str) -> None:
         body = [b"Hi ", b"again, ", b"FastStream!"]
         message = SimpleNamespace(
@@ -70,7 +62,7 @@ class TestBatchKafkaMetricsSettingsProvider(
             "messages_count": len(message.raw_message),
         }
 
-        provider = self.get_provider()
+        provider = self.get_settings_provider()
         attrs = provider.get_consume_attrs_from_message(message)
 
         assert attrs == expected_attrs

--- a/tests/prometheus/kafka/test_provider.py
+++ b/tests/prometheus/kafka/test_provider.py
@@ -27,7 +27,8 @@ class LocalBaseKafkaMetricsSettingsProviderTestcase(
 
 
 class TestKafkaMetricsSettingsProvider(
-    KafkaPrometheusSettings, LocalBaseKafkaMetricsSettingsProviderTestcase
+    KafkaPrometheusSettings,
+    LocalBaseKafkaMetricsSettingsProviderTestcase,
 ):
     def test_get_consume_attrs_from_message(self, queue: str) -> None:
         body = b"Hello"
@@ -46,7 +47,8 @@ class TestKafkaMetricsSettingsProvider(
 
 
 class TestBatchKafkaMetricsSettingsProvider(
-    BatchKafkaPrometheusSettings, LocalBaseKafkaMetricsSettingsProviderTestcase
+    BatchKafkaPrometheusSettings,
+    LocalBaseKafkaMetricsSettingsProviderTestcase,
 ):
     def test_get_consume_attrs_from_message(self, queue: str) -> None:
         body = [b"Hi ", b"again, ", b"FastStream!"]

--- a/tests/prometheus/nats/basic.py
+++ b/tests/prometheus/nats/basic.py
@@ -1,15 +1,25 @@
 from typing import Any
 
-from faststream.nats import NatsBroker
 from faststream.nats.prometheus import NatsPrometheusMiddleware
+from faststream.nats.prometheus.provider import (
+    BatchNatsMetricsSettingsProvider,
+    NatsMetricsSettingsProvider,
+)
 from tests.brokers.nats.basic import NatsTestcaseConfig
 
 
-class NatsPrometheusSettings(NatsTestcaseConfig):
+class BaseNatsPrometheusSettings(NatsTestcaseConfig):
     messaging_system = "nats"
-
-    def get_broker(self, apply_types=False, **kwargs: Any) -> NatsBroker:
-        return NatsBroker(apply_types=apply_types, **kwargs)
 
     def get_middleware(self, **kwargs: Any) -> NatsPrometheusMiddleware:
         return NatsPrometheusMiddleware(**kwargs)
+
+
+class NatsPrometheusSettings(BaseNatsPrometheusSettings):
+    def get_settings_provider(self) -> NatsMetricsSettingsProvider:
+        return NatsMetricsSettingsProvider()
+
+
+class BatchNatsPrometheusSettings(BaseNatsPrometheusSettings):
+    def get_settings_provider(self) -> BatchNatsMetricsSettingsProvider:
+        return BatchNatsMetricsSettingsProvider()

--- a/tests/prometheus/rabbit/basic.py
+++ b/tests/prometheus/rabbit/basic.py
@@ -1,6 +1,8 @@
 from typing import Any
 
+from faststream.prometheus import MetricsSettingsProvider
 from faststream.rabbit.prometheus import RabbitPrometheusMiddleware
+from faststream.rabbit.prometheus.provider import RabbitMetricsSettingsProvider
 from tests.brokers.rabbit.basic import RabbitTestcaseConfig
 
 
@@ -9,3 +11,6 @@ class RabbitPrometheusSettings(RabbitTestcaseConfig):
 
     def get_middleware(self, **kwargs: Any) -> RabbitPrometheusMiddleware:
         return RabbitPrometheusMiddleware(**kwargs)
+
+    def get_settings_provider(self) -> MetricsSettingsProvider[Any]:
+        return RabbitMetricsSettingsProvider()

--- a/tests/prometheus/rabbit/test_provider.py
+++ b/tests/prometheus/rabbit/test_provider.py
@@ -3,8 +3,6 @@ from typing import Union
 
 import pytest
 
-from faststream.prometheus import MetricsSettingsProvider
-from faststream.rabbit.prometheus.provider import RabbitMetricsSettingsProvider
 from tests.prometheus.basic import LocalMetricsSettingsProviderTestcase
 
 from .basic import RabbitPrometheusSettings
@@ -14,10 +12,6 @@ class TestRabbitMetricsSettingsProvider(
     RabbitPrometheusSettings,
     LocalMetricsSettingsProviderTestcase,
 ):
-    @staticmethod
-    def get_provider() -> MetricsSettingsProvider:
-        return RabbitMetricsSettingsProvider()
-
     @pytest.mark.parametrize(
         "exchange",
         (
@@ -40,7 +34,7 @@ class TestRabbitMetricsSettingsProvider(
             body=body, raw_message=SimpleNamespace(exchange=exchange, routing_key=queue)
         )
 
-        provider = self.get_provider()
+        provider = self.get_settings_provider()
         attrs = provider.get_consume_attrs_from_message(message)
 
         assert attrs == expected_attrs
@@ -62,7 +56,7 @@ class TestRabbitMetricsSettingsProvider(
             exchange=SimpleNamespace(name=exchange), destination=queue
         )
 
-        provider = self.get_provider()
+        provider = self.get_settings_provider()
         destination_name = provider.get_publish_destination_name_from_cmd(command)
 
         assert destination_name == expected_destination_name

--- a/tests/prometheus/redis/basic.py
+++ b/tests/prometheus/redis/basic.py
@@ -1,11 +1,25 @@
 from typing import Any
 
 from faststream.redis.prometheus import RedisPrometheusMiddleware
+from faststream.redis.prometheus.provider import (
+    BatchRedisMetricsSettingsProvider,
+    RedisMetricsSettingsProvider,
+)
 from tests.brokers.redis.basic import RedisTestcaseConfig
 
 
-class RedisPrometheusSettings(RedisTestcaseConfig):
+class BaseRedisPrometheusSettings(RedisTestcaseConfig):
     messaging_system = "redis"
 
     def get_middleware(self, **kwargs: Any) -> RedisPrometheusMiddleware:
         return RedisPrometheusMiddleware(**kwargs)
+
+
+class RedisPrometheusSettings(BaseRedisPrometheusSettings):
+    def get_settings_provider(self) -> RedisMetricsSettingsProvider:
+        return RedisMetricsSettingsProvider()
+
+
+class BatchRedisPrometheusSettings(BaseRedisPrometheusSettings):
+    def get_settings_provider(self) -> BatchRedisMetricsSettingsProvider:
+        return BatchRedisMetricsSettingsProvider()

--- a/tests/prometheus/redis/test_redis.py
+++ b/tests/prometheus/redis/test_redis.py
@@ -1,6 +1,5 @@
 import asyncio
 from typing import Any
-from unittest.mock import Mock
 
 import pytest
 from prometheus_client import CollectorRegistry
@@ -12,24 +11,19 @@ from tests.brokers.redis.test_consume import TestConsume
 from tests.brokers.redis.test_publish import TestPublish
 from tests.prometheus.basic import LocalPrometheusTestcase, LocalRPCPrometheusTestcase
 
-from .basic import RedisPrometheusSettings
+from .basic import BatchRedisPrometheusSettings, RedisPrometheusSettings
 
 
 @pytest.mark.redis()
-class TestPrometheus(
-    RedisPrometheusSettings,
-    LocalPrometheusTestcase,
-    LocalRPCPrometheusTestcase,
-):
-    async def test_metrics_batch(
+class TestBatchPrometheus(BatchRedisPrometheusSettings, LocalPrometheusTestcase):
+    async def test_metrics(
         self,
         queue: str,
-    ):
+    ) -> None:
         event = asyncio.Event()
 
-        middleware = self.get_middleware(registry=CollectorRegistry())
-        metrics_manager_mock = Mock()
-        middleware._metrics_manager = metrics_manager_mock
+        registry = CollectorRegistry()
+        middleware = self.get_middleware(registry=registry)
 
         broker = self.get_broker(apply_types=True, middlewares=(middleware,))
 
@@ -47,16 +41,25 @@ class TestPrometheus(
         async with broker:
             await broker.start()
             tasks = (
-                asyncio.create_task(broker.publish_batch("hello", "world", list=queue)),
+                asyncio.create_task(broker.publish_batch("hel", "lo", list=queue)),
                 asyncio.create_task(event.wait()),
             )
             await asyncio.wait(tasks, timeout=self.timeout)
 
         assert event.is_set()
-        self.assert_consume_metrics(
-            metrics_manager=metrics_manager_mock, message=message, exception_class=None
+        self.assert_metrics(
+            registry=registry,
+            message=message,
+            exception_class=None,
         )
-        self.assert_publish_metrics(metrics_manager=metrics_manager_mock)
+
+
+@pytest.mark.redis()
+class TestPrometheus(
+    RedisPrometheusSettings,
+    LocalPrometheusTestcase,
+    LocalRPCPrometheusTestcase,
+): ...
 
 
 @pytest.mark.redis()

--- a/tests/prometheus/test_metrics.py
+++ b/tests/prometheus/test_metrics.py
@@ -1,5 +1,5 @@
 import random
-from typing import Optional, Any
+from typing import Any, Optional
 
 import pytest
 from prometheus_client import CollectorRegistry
@@ -7,11 +7,17 @@ from prometheus_client import CollectorRegistry
 from faststream.prometheus.container import MetricsContainer
 from faststream.prometheus.manager import MetricsManager
 from faststream.prometheus.types import ProcessingStatus, PublishingStatus
-from tests.prometheus.utils import get_received_messages_metric, get_received_messages_size_bytes_metric, \
-    get_received_messages_in_process_metric, get_received_processed_messages_metric, \
-    get_received_processed_messages_duration_seconds_metric, get_received_processed_messages_exceptions_metric, \
-    get_published_messages_metric, get_published_messages_duration_seconds_metric, \
-    get_published_messages_exceptions_metric
+from tests.prometheus.utils import (
+    get_published_messages_duration_seconds_metric,
+    get_published_messages_exceptions_metric,
+    get_published_messages_metric,
+    get_received_messages_in_process_metric,
+    get_received_messages_metric,
+    get_received_messages_size_bytes_metric,
+    get_received_processed_messages_duration_seconds_metric,
+    get_received_processed_messages_exceptions_metric,
+    get_received_processed_messages_metric,
+)
 
 
 class TestCaseMetrics:
@@ -178,7 +184,7 @@ class TestCaseMetrics:
             app_name=app_name,
             broker=broker,
             queue=queue,
-            messages_amount=messages_amount-1,
+            messages_amount=messages_amount - 1,
         )
 
         manager.add_received_message_in_process(

--- a/tests/prometheus/test_metrics.py
+++ b/tests/prometheus/test_metrics.py
@@ -129,6 +129,7 @@ class TestCaseMetrics:
             queue=queue,
             buckets=buckets,
             size=size,
+            messages_amount=1,
         )
 
         manager.observe_received_messages_size(size=size, broker=broker, handler=queue)

--- a/tests/prometheus/test_metrics.py
+++ b/tests/prometheus/test_metrics.py
@@ -1,22 +1,24 @@
 import random
-from typing import Optional
-from unittest.mock import ANY
+from typing import Optional, Any
 
 import pytest
-from dirty_equals import IsPositiveFloat, IsStr
-from prometheus_client import CollectorRegistry, Histogram, Metric
-from prometheus_client.samples import Sample
+from prometheus_client import CollectorRegistry
 
 from faststream.prometheus.container import MetricsContainer
 from faststream.prometheus.manager import MetricsManager
 from faststream.prometheus.types import ProcessingStatus, PublishingStatus
+from tests.prometheus.utils import get_received_messages_metric, get_received_messages_size_bytes_metric, \
+    get_received_messages_in_process_metric, get_received_processed_messages_metric, \
+    get_received_processed_messages_duration_seconds_metric, get_received_processed_messages_exceptions_metric, \
+    get_published_messages_metric, get_published_messages_duration_seconds_metric, \
+    get_published_messages_exceptions_metric
 
 
 class TestCaseMetrics:
     @staticmethod
     def create_metrics_manager(
-        app_name: Optional[str] = None,
-        metrics_prefix: Optional[str] = None,
+        app_name: str,
+        metrics_prefix: str,
         received_messages_size_buckets: Optional[list[float]] = None,
     ) -> MetricsManager:
         registry = CollectorRegistry()
@@ -64,28 +66,13 @@ class TestCaseMetrics:
             metrics_prefix=metrics_prefix,
         )
 
-        expected = Metric(
-            name=f"{metrics_prefix}_received_messages",
-            documentation="Count of received messages by broker and handler",
-            unit="",
-            typ="counter",
+        expected = get_received_messages_metric(
+            app_name=app_name,
+            metrics_prefix=metrics_prefix,
+            queue=queue,
+            broker=broker,
+            messages_amount=messages_amount,
         )
-        expected.samples = [
-            Sample(
-                name=f"{metrics_prefix}_received_messages_total",
-                labels={"app_name": app_name, "broker": broker, "handler": queue},
-                value=float(messages_amount),
-                timestamp=None,
-                exemplar=None,
-            ),
-            Sample(
-                name=f"{metrics_prefix}_received_messages_created",
-                labels={"app_name": app_name, "broker": broker, "handler": queue},
-                value=IsPositiveFloat,
-                timestamp=None,
-                exemplar=None,
-            ),
-        ]
 
         manager.add_received_message(
             amount=messages_amount, broker=broker, handler=queue
@@ -110,7 +97,7 @@ class TestCaseMetrics:
         broker: str,
         is_default_buckets: bool,
     ) -> None:
-        manager_kwargs = {
+        manager_kwargs: dict[str, Any] = {
             "app_name": app_name,
             "metrics_prefix": metrics_prefix,
         }
@@ -129,50 +116,14 @@ class TestCaseMetrics:
             else custom_buckets
         )
 
-        expected = Metric(
-            name=f"{metrics_prefix}_received_messages_size_bytes",
-            documentation="Histogram of received messages size in bytes by broker and handler",
-            unit="",
-            typ="histogram",
+        expected = get_received_messages_size_bytes_metric(
+            metrics_prefix=metrics_prefix,
+            app_name=app_name,
+            broker=broker,
+            queue=queue,
+            buckets=buckets,
+            size=size,
         )
-        expected.samples = [
-            *[
-                Sample(
-                    name=f"{metrics_prefix}_received_messages_size_bytes_bucket",
-                    labels={
-                        "app_name": app_name,
-                        "broker": broker,
-                        "handler": queue,
-                        "le": IsStr,
-                    },
-                    value=1.0,
-                    timestamp=None,
-                    exemplar=None,
-                )
-                for _ in buckets
-            ],
-            Sample(
-                name=f"{metrics_prefix}_received_messages_size_bytes_count",
-                labels={"app_name": app_name, "broker": broker, "handler": queue},
-                value=1.0,
-                timestamp=None,
-                exemplar=None,
-            ),
-            Sample(
-                name=f"{metrics_prefix}_received_messages_size_bytes_sum",
-                labels={"app_name": app_name, "broker": broker, "handler": queue},
-                value=size,
-                timestamp=None,
-                exemplar=None,
-            ),
-            Sample(
-                name=f"{metrics_prefix}_received_messages_size_bytes_created",
-                labels={"app_name": app_name, "broker": broker, "handler": queue},
-                value=ANY,
-                timestamp=None,
-                exemplar=None,
-            ),
-        ]
 
         manager.observe_received_messages_size(size=size, broker=broker, handler=queue)
 
@@ -193,21 +144,13 @@ class TestCaseMetrics:
             metrics_prefix=metrics_prefix,
         )
 
-        expected = Metric(
-            name=f"{metrics_prefix}_received_messages_in_process",
-            documentation="Gauge of received messages in process by broker and handler",
-            unit="",
-            typ="gauge",
+        expected = get_received_messages_in_process_metric(
+            metrics_prefix=metrics_prefix,
+            app_name=app_name,
+            broker=broker,
+            queue=queue,
+            messages_amount=messages_amount,
         )
-        expected.samples = [
-            Sample(
-                name=f"{metrics_prefix}_received_messages_in_process",
-                labels={"app_name": app_name, "broker": broker, "handler": queue},
-                value=float(messages_amount),
-                timestamp=None,
-                exemplar=None,
-            ),
-        ]
 
         manager.add_received_message_in_process(
             amount=messages_amount, broker=broker, handler=queue
@@ -230,21 +173,13 @@ class TestCaseMetrics:
             metrics_prefix=metrics_prefix,
         )
 
-        expected = Metric(
-            name=f"{metrics_prefix}_received_messages_in_process",
-            documentation="Gauge of received messages in process by broker and handler",
-            unit="",
-            typ="gauge",
+        expected = get_received_messages_in_process_metric(
+            metrics_prefix=metrics_prefix,
+            app_name=app_name,
+            broker=broker,
+            queue=queue,
+            messages_amount=messages_amount-1,
         )
-        expected.samples = [
-            Sample(
-                name=f"{metrics_prefix}_received_messages_in_process",
-                labels={"app_name": app_name, "broker": broker, "handler": queue},
-                value=float(messages_amount - 1),
-                timestamp=None,
-                exemplar=None,
-            ),
-        ]
 
         manager.add_received_message_in_process(
             amount=messages_amount, broker=broker, handler=queue
@@ -281,38 +216,14 @@ class TestCaseMetrics:
             metrics_prefix=metrics_prefix,
         )
 
-        expected = Metric(
-            name=f"{metrics_prefix}_received_processed_messages",
-            documentation="Count of received processed messages by broker, handler and status",
-            unit="",
-            typ="counter",
+        expected = get_received_processed_messages_metric(
+            metrics_prefix=metrics_prefix,
+            app_name=app_name,
+            broker=broker,
+            queue=queue,
+            messages_amount=messages_amount,
+            status=status,
         )
-        expected.samples = [
-            Sample(
-                name=f"{metrics_prefix}_received_processed_messages_total",
-                labels={
-                    "app_name": app_name,
-                    "broker": broker,
-                    "handler": queue,
-                    "status": status.value,
-                },
-                value=float(messages_amount),
-                timestamp=None,
-                exemplar=None,
-            ),
-            Sample(
-                name=f"{metrics_prefix}_received_processed_messages_created",
-                labels={
-                    "app_name": app_name,
-                    "broker": broker,
-                    "handler": queue,
-                    "status": status.value,
-                },
-                value=IsPositiveFloat,
-                timestamp=None,
-                exemplar=None,
-            ),
-        ]
 
         manager.add_received_processed_message(
             amount=messages_amount,
@@ -339,50 +250,13 @@ class TestCaseMetrics:
 
         duration = 0.001
 
-        expected = Metric(
-            name=f"{metrics_prefix}_received_processed_messages_duration_seconds",
-            documentation="Histogram of received processed messages duration in seconds by broker and handler",
-            unit="",
-            typ="histogram",
+        expected = get_received_processed_messages_duration_seconds_metric(
+            metrics_prefix=metrics_prefix,
+            app_name=app_name,
+            broker=broker,
+            queue=queue,
+            duration=duration,
         )
-        expected.samples = [
-            *[
-                Sample(
-                    name=f"{metrics_prefix}_received_processed_messages_duration_seconds_bucket",
-                    labels={
-                        "app_name": app_name,
-                        "broker": broker,
-                        "handler": queue,
-                        "le": IsStr,
-                    },
-                    value=1.0,
-                    timestamp=None,
-                    exemplar=None,
-                )
-                for _ in Histogram.DEFAULT_BUCKETS
-            ],
-            Sample(
-                name=f"{metrics_prefix}_received_processed_messages_duration_seconds_count",
-                labels={"app_name": app_name, "broker": broker, "handler": queue},
-                value=1.0,
-                timestamp=None,
-                exemplar=None,
-            ),
-            Sample(
-                name=f"{metrics_prefix}_received_processed_messages_duration_seconds_sum",
-                labels={"app_name": app_name, "broker": broker, "handler": queue},
-                value=duration,
-                timestamp=None,
-                exemplar=None,
-            ),
-            Sample(
-                name=f"{metrics_prefix}_received_processed_messages_duration_seconds_created",
-                labels={"app_name": app_name, "broker": broker, "handler": queue},
-                value=ANY,
-                timestamp=None,
-                exemplar=None,
-            ),
-        ]
 
         manager.observe_received_processed_message_duration(
             duration=duration,
@@ -409,38 +283,13 @@ class TestCaseMetrics:
             metrics_prefix=metrics_prefix,
         )
 
-        expected = Metric(
-            name=f"{metrics_prefix}_received_processed_messages_exceptions",
-            documentation="Count of received processed messages exceptions by broker, handler and exception_type",
-            unit="",
-            typ="counter",
+        expected = get_received_processed_messages_exceptions_metric(
+            metrics_prefix=metrics_prefix,
+            app_name=app_name,
+            broker=broker,
+            queue=queue,
+            exception_type=exception_type,
         )
-        expected.samples = [
-            Sample(
-                name=f"{metrics_prefix}_received_processed_messages_exceptions_total",
-                labels={
-                    "app_name": app_name,
-                    "broker": broker,
-                    "handler": queue,
-                    "exception_type": exception_type,
-                },
-                value=1.0,
-                timestamp=None,
-                exemplar=None,
-            ),
-            Sample(
-                name=f"{metrics_prefix}_received_processed_messages_exceptions_created",
-                labels={
-                    "app_name": app_name,
-                    "broker": broker,
-                    "handler": queue,
-                    "exception_type": exception_type,
-                },
-                value=IsPositiveFloat,
-                timestamp=None,
-                exemplar=None,
-            ),
-        ]
 
         manager.add_received_processed_message_exception(
             exception_type=exception_type,
@@ -475,38 +324,13 @@ class TestCaseMetrics:
             metrics_prefix=metrics_prefix,
         )
 
-        expected = Metric(
-            name=f"{metrics_prefix}_published_messages",
-            documentation="Count of published messages by destination and status",
-            unit="",
-            typ="counter",
+        expected = get_published_messages_metric(
+            metrics_prefix=metrics_prefix,
+            app_name=app_name,
+            broker=broker,
+            queue=queue,
+            status=status,
         )
-        expected.samples = [
-            Sample(
-                name=f"{metrics_prefix}_published_messages_total",
-                labels={
-                    "app_name": app_name,
-                    "broker": broker,
-                    "destination": queue,
-                    "status": status.value,
-                },
-                value=1.0,
-                timestamp=None,
-                exemplar=None,
-            ),
-            Sample(
-                name=f"{metrics_prefix}_published_messages_created",
-                labels={
-                    "app_name": app_name,
-                    "broker": broker,
-                    "destination": queue,
-                    "status": status.value,
-                },
-                value=IsPositiveFloat,
-                timestamp=None,
-                exemplar=None,
-            ),
-        ]
 
         manager.add_published_message(
             status=status,
@@ -532,50 +356,13 @@ class TestCaseMetrics:
 
         duration = 0.001
 
-        expected = Metric(
-            name=f"{metrics_prefix}_published_messages_duration_seconds",
-            documentation="Histogram of published messages duration in seconds by broker and destination",
-            unit="",
-            typ="histogram",
+        expected = get_published_messages_duration_seconds_metric(
+            metrics_prefix=metrics_prefix,
+            app_name=app_name,
+            broker=broker,
+            queue=queue,
+            duration=duration,
         )
-        expected.samples = [
-            *[
-                Sample(
-                    name=f"{metrics_prefix}_published_messages_duration_seconds_bucket",
-                    labels={
-                        "app_name": app_name,
-                        "broker": broker,
-                        "destination": queue,
-                        "le": IsStr,
-                    },
-                    value=1.0,
-                    timestamp=None,
-                    exemplar=None,
-                )
-                for _ in Histogram.DEFAULT_BUCKETS
-            ],
-            Sample(
-                name=f"{metrics_prefix}_published_messages_duration_seconds_count",
-                labels={"app_name": app_name, "broker": broker, "destination": queue},
-                value=1.0,
-                timestamp=None,
-                exemplar=None,
-            ),
-            Sample(
-                name=f"{metrics_prefix}_published_messages_duration_seconds_sum",
-                labels={"app_name": app_name, "broker": broker, "destination": queue},
-                value=duration,
-                timestamp=None,
-                exemplar=None,
-            ),
-            Sample(
-                name=f"{metrics_prefix}_published_messages_duration_seconds_created",
-                labels={"app_name": app_name, "broker": broker, "destination": queue},
-                value=IsPositiveFloat,
-                timestamp=None,
-                exemplar=None,
-            ),
-        ]
 
         manager.observe_published_message_duration(
             duration=duration,
@@ -600,38 +387,13 @@ class TestCaseMetrics:
             metrics_prefix=metrics_prefix,
         )
 
-        expected = Metric(
-            name=f"{metrics_prefix}_published_messages_exceptions",
-            documentation="Count of published messages exceptions by broker, destination and exception_type",
-            unit="",
-            typ="counter",
+        expected = get_published_messages_exceptions_metric(
+            metrics_prefix=metrics_prefix,
+            app_name=app_name,
+            broker=broker,
+            queue=queue,
+            exception_type=exception_type,
         )
-        expected.samples = [
-            Sample(
-                name=f"{metrics_prefix}_published_messages_exceptions_total",
-                labels={
-                    "app_name": app_name,
-                    "broker": broker,
-                    "destination": queue,
-                    "exception_type": exception_type,
-                },
-                value=1.0,
-                timestamp=None,
-                exemplar=None,
-            ),
-            Sample(
-                name=f"{metrics_prefix}_published_messages_exceptions_created",
-                labels={
-                    "app_name": app_name,
-                    "broker": broker,
-                    "destination": queue,
-                    "exception_type": exception_type,
-                },
-                value=IsPositiveFloat,
-                timestamp=None,
-                exemplar=None,
-            ),
-        ]
 
         manager.add_published_message_exception(
             exception_type=exception_type,

--- a/tests/prometheus/test_metrics.py
+++ b/tests/prometheus/test_metrics.py
@@ -295,6 +295,7 @@ class TestCaseMetrics:
             broker=broker,
             queue=queue,
             exception_type=exception_type,
+            exceptions_amount=1,
         )
 
         manager.add_received_processed_message_exception(
@@ -336,6 +337,7 @@ class TestCaseMetrics:
             broker=broker,
             queue=queue,
             status=status,
+            messages_amount=1,
         )
 
         manager.add_published_message(

--- a/tests/prometheus/utils.py
+++ b/tests/prometheus/utils.py
@@ -1,4 +1,5 @@
-from typing import Sequence, cast
+from collections.abc import Sequence
+from typing import cast
 
 from dirty_equals import IsPositiveFloat, IsStr
 from prometheus_client import Histogram, Metric
@@ -8,12 +9,12 @@ from faststream.prometheus.types import ProcessingStatus, PublishingStatus
 
 
 def get_received_messages_metric(
-        *,
-        metrics_prefix: str,
-        app_name: str,
-        broker: str,
-        queue: str,
-        messages_amount: int,
+    *,
+    metrics_prefix: str,
+    app_name: str,
+    broker: str,
+    queue: str,
+    messages_amount: int,
 ) -> Metric:
     metric = Metric(
         name=f"{metrics_prefix}_received_messages",
@@ -51,11 +52,11 @@ def get_received_messages_size_bytes_metric(
     size: int,
 ) -> Metric:
     metric = Metric(
-            name=f"{metrics_prefix}_received_messages_size_bytes",
-            documentation="Histogram of received messages size in bytes by broker and handler",
-            unit="",
-            typ="histogram",
-        )
+        name=f"{metrics_prefix}_received_messages_size_bytes",
+        documentation="Histogram of received messages size in bytes by broker and handler",
+        unit="",
+        typ="histogram",
+    )
     metric.samples = [
         *[
             Sample(
@@ -99,12 +100,12 @@ def get_received_messages_size_bytes_metric(
 
 
 def get_received_messages_in_process_metric(
-        *,
-        metrics_prefix: str,
-        app_name: str,
-        broker: str,
-        queue: str,
-        messages_amount: int,
+    *,
+    metrics_prefix: str,
+    app_name: str,
+    broker: str,
+    queue: str,
+    messages_amount: int,
 ) -> Metric:
     metric = Metric(
         name=f"{metrics_prefix}_received_messages_in_process",

--- a/tests/prometheus/utils.py
+++ b/tests/prometheus/utils.py
@@ -1,0 +1,414 @@
+from typing import Sequence, cast
+
+from dirty_equals import IsPositiveFloat, IsStr
+from prometheus_client import Histogram, Metric
+from prometheus_client.samples import Sample
+
+from faststream.prometheus.types import ProcessingStatus, PublishingStatus
+
+
+def get_received_messages_metric(
+        *,
+        metrics_prefix: str,
+        app_name: str,
+        broker: str,
+        queue: str,
+        messages_amount: int,
+) -> Metric:
+    metric = Metric(
+        name=f"{metrics_prefix}_received_messages",
+        documentation="Count of received messages by broker and handler",
+        unit="",
+        typ="counter",
+    )
+    metric.samples = [
+        Sample(
+            name=f"{metrics_prefix}_received_messages_total",
+            labels={"app_name": app_name, "broker": broker, "handler": queue},
+            value=float(messages_amount),
+            timestamp=None,
+            exemplar=None,
+        ),
+        Sample(
+            name=f"{metrics_prefix}_received_messages_created",
+            labels={"app_name": app_name, "broker": broker, "handler": queue},
+            value=cast(float, IsPositiveFloat),
+            timestamp=None,
+            exemplar=None,
+        ),
+    ]
+
+    return metric
+
+
+def get_received_messages_size_bytes_metric(
+    *,
+    metrics_prefix: str,
+    app_name: str,
+    broker: str,
+    queue: str,
+    buckets: Sequence[float],
+    size: int,
+) -> Metric:
+    metric = Metric(
+            name=f"{metrics_prefix}_received_messages_size_bytes",
+            documentation="Histogram of received messages size in bytes by broker and handler",
+            unit="",
+            typ="histogram",
+        )
+    metric.samples = [
+        *[
+            Sample(
+                name=f"{metrics_prefix}_received_messages_size_bytes_bucket",
+                labels={
+                    "app_name": app_name,
+                    "broker": broker,
+                    "handler": queue,
+                    "le": cast(str, IsStr),
+                },
+                value=1.0,
+                timestamp=None,
+                exemplar=None,
+            )
+            for _ in buckets
+        ],
+        Sample(
+            name=f"{metrics_prefix}_received_messages_size_bytes_count",
+            labels={"app_name": app_name, "broker": broker, "handler": queue},
+            value=1.0,
+            timestamp=None,
+            exemplar=None,
+        ),
+        Sample(
+            name=f"{metrics_prefix}_received_messages_size_bytes_sum",
+            labels={"app_name": app_name, "broker": broker, "handler": queue},
+            value=size,
+            timestamp=None,
+            exemplar=None,
+        ),
+        Sample(
+            name=f"{metrics_prefix}_received_messages_size_bytes_created",
+            labels={"app_name": app_name, "broker": broker, "handler": queue},
+            value=cast(float, IsPositiveFloat),
+            timestamp=None,
+            exemplar=None,
+        ),
+    ]
+
+    return metric
+
+
+def get_received_messages_in_process_metric(
+        *,
+        metrics_prefix: str,
+        app_name: str,
+        broker: str,
+        queue: str,
+        messages_amount: int,
+) -> Metric:
+    metric = Metric(
+        name=f"{metrics_prefix}_received_messages_in_process",
+        documentation="Gauge of received messages in process by broker and handler",
+        unit="",
+        typ="gauge",
+    )
+    metric.samples = [
+        Sample(
+            name=f"{metrics_prefix}_received_messages_in_process",
+            labels={"app_name": app_name, "broker": broker, "handler": queue},
+            value=float(messages_amount),
+            timestamp=None,
+            exemplar=None,
+        ),
+    ]
+
+    return metric
+
+
+def get_received_processed_messages_metric(
+    *,
+    metrics_prefix: str,
+    app_name: str,
+    broker: str,
+    queue: str,
+    messages_amount: int,
+    status: ProcessingStatus,
+) -> Metric:
+    metric = Metric(
+        name=f"{metrics_prefix}_received_processed_messages",
+        documentation="Count of received processed messages by broker, handler and status",
+        unit="",
+        typ="counter",
+    )
+    metric.samples = [
+        Sample(
+            name=f"{metrics_prefix}_received_processed_messages_total",
+            labels={
+                "app_name": app_name,
+                "broker": broker,
+                "handler": queue,
+                "status": status.value,
+            },
+            value=float(messages_amount),
+            timestamp=None,
+            exemplar=None,
+        ),
+        Sample(
+            name=f"{metrics_prefix}_received_processed_messages_created",
+            labels={
+                "app_name": app_name,
+                "broker": broker,
+                "handler": queue,
+                "status": status.value,
+            },
+            value=cast(float, IsPositiveFloat),
+            timestamp=None,
+            exemplar=None,
+        ),
+    ]
+
+    return metric
+
+
+def get_received_processed_messages_duration_seconds_metric(
+    *,
+    metrics_prefix: str,
+    app_name: str,
+    broker: str,
+    queue: str,
+    duration: float,
+) -> Metric:
+    metric = Metric(
+        name=f"{metrics_prefix}_received_processed_messages_duration_seconds",
+        documentation="Histogram of received processed messages duration in seconds by broker and handler",
+        unit="",
+        typ="histogram",
+    )
+    metric.samples = [
+        *[
+            Sample(
+                name=f"{metrics_prefix}_received_processed_messages_duration_seconds_bucket",
+                labels={
+                    "app_name": app_name,
+                    "broker": broker,
+                    "handler": queue,
+                    "le": cast(str, IsStr),
+                },
+                value=1.0,
+                timestamp=None,
+                exemplar=None,
+            )
+            for _ in Histogram.DEFAULT_BUCKETS
+        ],
+        Sample(
+            name=f"{metrics_prefix}_received_processed_messages_duration_seconds_count",
+            labels={"app_name": app_name, "broker": broker, "handler": queue},
+            value=1.0,
+            timestamp=None,
+            exemplar=None,
+        ),
+        Sample(
+            name=f"{metrics_prefix}_received_processed_messages_duration_seconds_sum",
+            labels={"app_name": app_name, "broker": broker, "handler": queue},
+            value=duration,
+            timestamp=None,
+            exemplar=None,
+        ),
+        Sample(
+            name=f"{metrics_prefix}_received_processed_messages_duration_seconds_created",
+            labels={"app_name": app_name, "broker": broker, "handler": queue},
+            value=cast(float, IsPositiveFloat),
+            timestamp=None,
+            exemplar=None,
+        ),
+    ]
+
+    return metric
+
+
+def get_received_processed_messages_exceptions_metric(
+    *,
+    metrics_prefix: str,
+    app_name: str,
+    broker: str,
+    queue: str,
+    exception_type: str,
+) -> Metric:
+    metric = Metric(
+        name=f"{metrics_prefix}_received_processed_messages_exceptions",
+        documentation="Count of received processed messages exceptions by broker, handler and exception_type",
+        unit="",
+        typ="counter",
+    )
+    metric.samples = [
+        Sample(
+            name=f"{metrics_prefix}_received_processed_messages_exceptions_total",
+            labels={
+                "app_name": app_name,
+                "broker": broker,
+                "handler": queue,
+                "exception_type": exception_type,
+            },
+            value=1.0,
+            timestamp=None,
+            exemplar=None,
+        ),
+        Sample(
+            name=f"{metrics_prefix}_received_processed_messages_exceptions_created",
+            labels={
+                "app_name": app_name,
+                "broker": broker,
+                "handler": queue,
+                "exception_type": exception_type,
+            },
+            value=cast(float, IsPositiveFloat),
+            timestamp=None,
+            exemplar=None,
+        ),
+    ]
+
+    return metric
+
+
+def get_published_messages_metric(
+    *,
+    metrics_prefix: str,
+    app_name: str,
+    broker: str,
+    queue: str,
+    status: PublishingStatus,
+) -> Metric:
+    metric = Metric(
+        name=f"{metrics_prefix}_published_messages",
+        documentation="Count of published messages by destination and status",
+        unit="",
+        typ="counter",
+    )
+    metric.samples = [
+        Sample(
+            name=f"{metrics_prefix}_published_messages_total",
+            labels={
+                "app_name": app_name,
+                "broker": broker,
+                "destination": queue,
+                "status": status.value,
+            },
+            value=1.0,
+            timestamp=None,
+            exemplar=None,
+        ),
+        Sample(
+            name=f"{metrics_prefix}_published_messages_created",
+            labels={
+                "app_name": app_name,
+                "broker": broker,
+                "destination": queue,
+                "status": status.value,
+            },
+            value=cast(float, IsPositiveFloat),
+            timestamp=None,
+            exemplar=None,
+        ),
+    ]
+
+    return metric
+
+
+def get_published_messages_duration_seconds_metric(
+    *,
+    metrics_prefix: str,
+    app_name: str,
+    broker: str,
+    queue: str,
+    duration: float,
+) -> Metric:
+    metric = Metric(
+        name=f"{metrics_prefix}_published_messages_duration_seconds",
+        documentation="Histogram of published messages duration in seconds by broker and destination",
+        unit="",
+        typ="histogram",
+    )
+    metric.samples = [
+        *[
+            Sample(
+                name=f"{metrics_prefix}_published_messages_duration_seconds_bucket",
+                labels={
+                    "app_name": app_name,
+                    "broker": broker,
+                    "destination": queue,
+                    "le": cast(str, IsStr),
+                },
+                value=1.0,
+                timestamp=None,
+                exemplar=None,
+            )
+            for _ in Histogram.DEFAULT_BUCKETS
+        ],
+        Sample(
+            name=f"{metrics_prefix}_published_messages_duration_seconds_count",
+            labels={"app_name": app_name, "broker": broker, "destination": queue},
+            value=1.0,
+            timestamp=None,
+            exemplar=None,
+        ),
+        Sample(
+            name=f"{metrics_prefix}_published_messages_duration_seconds_sum",
+            labels={"app_name": app_name, "broker": broker, "destination": queue},
+            value=duration,
+            timestamp=None,
+            exemplar=None,
+        ),
+        Sample(
+            name=f"{metrics_prefix}_published_messages_duration_seconds_created",
+            labels={"app_name": app_name, "broker": broker, "destination": queue},
+            value=cast(float, IsPositiveFloat),
+            timestamp=None,
+            exemplar=None,
+        ),
+    ]
+
+    return metric
+
+
+def get_published_messages_exceptions_metric(
+    *,
+    metrics_prefix: str,
+    app_name: str,
+    broker: str,
+    queue: str,
+    exception_type: str,
+) -> Metric:
+    metric = Metric(
+        name=f"{metrics_prefix}_published_messages_exceptions",
+        documentation="Count of published messages exceptions by broker, destination and exception_type",
+        unit="",
+        typ="counter",
+    )
+    metric.samples = [
+        Sample(
+            name=f"{metrics_prefix}_published_messages_exceptions_total",
+            labels={
+                "app_name": app_name,
+                "broker": broker,
+                "destination": queue,
+                "exception_type": exception_type,
+            },
+            value=1.0,
+            timestamp=None,
+            exemplar=None,
+        ),
+        Sample(
+            name=f"{metrics_prefix}_published_messages_exceptions_created",
+            labels={
+                "app_name": app_name,
+                "broker": broker,
+                "destination": queue,
+                "exception_type": exception_type,
+            },
+            value=cast(float, IsPositiveFloat),
+            timestamp=None,
+            exemplar=None,
+        ),
+    ]
+
+    return metric


### PR DESCRIPTION
# Description

Integration tests with prometheus work on mocks, this is not good, so I redesigned the structure of the tests and removed the mocks.

also the bug `batch_bodies` was fixed

was: `broker.publish("", queue)` => `command.batch_bodies == ()`

now: `broker.publish("", queue)` => `command.batch_bodies == ("",)`
(this also works for `b""`)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (a non-breaking change that resolves an issue)
- [x] New feature (a non-breaking change that adds functionality)

## Checklist

- [ ] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [ ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
