### PR TITLE
feat: Non-blocking polling for confluent kafka driver.

### DIFF
--- a/faststream/confluent/client.py
+++ b/faststream/confluent/client.py
@@ -350,7 +350,11 @@ class AsyncConfluentConsumer:
 
     async def commit(self, asynchronous: bool = True) -> None:
         """Commits the offsets of all messages returned by the last poll operation."""
-        await call_or_await(self.consumer.commit, asynchronous=asynchronous)
+        if asynchronous:
+            # Asynchronous commit is non-blocking:
+            self.consumer.commit(asynchronous=True)
+        else:
+            await call_or_await(self.consumer.commit, asynchronous=False)
 
     async def stop(self) -> None:
         """Stops the Kafka consumer and releases all resources."""

--- a/faststream/confluent/subscriber/usecase.py
+++ b/faststream/confluent/subscriber/usecase.py
@@ -378,17 +378,13 @@ class BatchSubscriber(LogicSubscriber[Tuple[Message, ...]]):
 
     async def get_msg(self) -> Optional[Tuple["Message", ...]]:
         assert self.consumer, "You should setup subscriber at first."  # nosec B101
-
-        messages = await self.consumer.getmany(
-            timeout=self.polling_interval,
-            max_records=self.max_records,
+        return (
+            await self.consumer.getmany(
+                timeout=self.polling_interval,
+                max_records=self.max_records,
+            )
+            or None
         )
-
-        if not messages:  # TODO: why we are sleeping here?
-            await anyio.sleep(self.polling_interval)
-            return None
-
-        return messages
 
     def get_log_context(
         self,


### PR DESCRIPTION
# Description

This request pool is strongly inspired by an issue from the confluent-kafka-python project: https://github.com/confluentinc/confluent-kafka-python/issues/612. I'm trying to stop using the `call_or_wait` function for the main message consuming flow.

Fixes #1904

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [x] Bug fix (a non-breaking change that resolves an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
