### PR TITLE
Separated thread for confluent kafka consumer client.

### DIFF
--- a/faststream/_internal/utils/functions.py
+++ b/faststream/_internal/utils/functions.py
@@ -1,9 +1,12 @@
+import asyncio
 from collections.abc import AsyncIterator, Awaitable, Iterator
+from concurrent.futures import Executor
 from contextlib import asynccontextmanager, contextmanager
-from functools import wraps
+from functools import partial, wraps
 from typing import (
     Any,
     Callable,
+    Optional,
     TypeVar,
     Union,
     cast,
@@ -80,3 +83,8 @@ def drop_response_type(model: CallModel) -> CallModel:
 
 async def return_input(x: Any) -> Any:
     return x
+
+
+async def run_in_executor(executor: Optional[Executor], func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(executor, partial(func, *args, **kwargs))

--- a/faststream/confluent/subscriber/usecase.py
+++ b/faststream/confluent/subscriber/usecase.py
@@ -335,17 +335,13 @@ class BatchSubscriber(LogicSubscriber[tuple[Message, ...]]):
 
     async def get_msg(self) -> Optional[tuple["Message", ...]]:
         assert self.consumer, "You should setup subscriber at first."  # nosec B101
-
-        messages = await self.consumer.getmany(
-            timeout=self.polling_interval,
-            max_records=self.max_records,
+        return (
+            await self.consumer.getmany(
+                timeout=self.polling_interval,
+                max_records=self.max_records,
+            )
+            or None
         )
-
-        if not messages:  # TODO: why we are sleeping here?
-            await anyio.sleep(self.polling_interval)
-            return None
-
-        return messages
 
     def get_log_context(
         self,

--- a/faststream/confluent/subscriber/usecase.py
+++ b/faststream/confluent/subscriber/usecase.py
@@ -131,11 +131,11 @@ class LogicSubscriber(TasksMixin, SubscriberUsecase[MsgType]):
             self.add_task(self._consume())
 
     async def close(self) -> None:
+        await super().close()
+
         if self.consumer is not None:
             await self.consumer.stop()
             self.consumer = None
-
-        await super().close()
 
     @override
     async def get_one(


### PR DESCRIPTION
# Description

Fixes https://github.com/airtai/faststream/issues/1904

All consumer operations are guaranteed to run in a separate thread. This allows us to no longer use `asyncio.Lock`, and also does not block threads from the shared pool.

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [ ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
