### PR TITLE
Confluent kafka producer refactoring.

### DIFF
--- a/faststream/confluent/client.py
+++ b/faststream/confluent/client.py
@@ -138,7 +138,7 @@ class AsyncConfluentProducer:
         timestamp_ms: Optional[int] = None,
         headers: Optional[list[tuple[str, Union[str, bytes]]]] = None,
         no_confirm: bool = False,
-    ) -> "asyncio.Future":
+    ) -> "Union[asyncio.Future[Optional[Message]], Optional[Message]]":
         """Sends a single message to a Kafka topic."""
         kwargs: _SendKwargs = {
             "value": value,
@@ -152,23 +152,22 @@ class AsyncConfluentProducer:
         if timestamp_ms is not None:
             kwargs["timestamp"] = timestamp_ms
 
-        if not no_confirm:
-            loop = asyncio.get_running_loop()
-            result_future: asyncio.Future[Optional[Message]] = loop.create_future()
+        loop = asyncio.get_running_loop()
+        result_future: asyncio.Future[Optional[Message]] = loop.create_future()
 
-            def ack_callback(err: Any, msg: Optional[Message]) -> None:
-                if err or (msg is not None and (err := msg.error())):
-                    loop.call_soon_threadsafe(result_future.set_exception, KafkaException(err))
-                else:
-                    loop.call_soon_threadsafe(result_future.set_result, msg)
+        def ack_callback(err: Any, msg: Optional[Message]) -> None:
+            if err or (msg is not None and (err := msg.error())):
+                loop.call_soon_threadsafe(result_future.set_exception, KafkaException(err))
+            else:
+                loop.call_soon_threadsafe(result_future.set_result, msg)
 
-            kwargs["on_delivery"] = ack_callback
+        kwargs["on_delivery"] = ack_callback
 
         # should be sync to prevent segfault
         self.producer.produce(topic, **kwargs)
 
         if not no_confirm:
-            await result_future
+            return await result_future
         return result_future
 
     def create_batch(self) -> "BatchBuilder":

--- a/faststream/confluent/publisher/producer.py
+++ b/faststream/confluent/publisher/producer.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from typing_extensions import override
 
@@ -12,6 +12,8 @@ from .state import EmptyProducerState, ProducerState, RealProducer
 
 if TYPE_CHECKING:
     import asyncio
+
+    from confluent_kafka import Message
 
     from faststream._internal.types import CustomCallable
     from faststream.confluent.client import AsyncConfluentProducer
@@ -50,7 +52,7 @@ class AsyncConfluentFastProducer(ProducerProto):
     async def publish(  # type: ignore[override]
         self,
         cmd: "KafkaPublishCommand",
-    ) -> "asyncio.Future":
+    ) -> "Union[asyncio.Future[Optional[Message]], Optional[Message]]":
         """Publish a message to a topic."""
         message, content_type = encode_message(cmd.body)
 

--- a/faststream/confluent/publisher/producer.py
+++ b/faststream/confluent/publisher/producer.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, NoReturn, Optional, Union
 
 from typing_extensions import override
 
@@ -45,7 +45,7 @@ class AsyncConfluentFastProducer(ProducerProto):
     def __bool__(self) -> bool:
         return bool(self._producer)
 
-    async def ping(self, timeout: float) -> None:
+    async def ping(self, timeout: float) -> bool:
         return await self._producer.ping(timeout=timeout)
 
     @override
@@ -71,7 +71,8 @@ class AsyncConfluentFastProducer(ProducerProto):
             no_confirm=cmd.no_confirm,
         )
 
-    async def publish_batch(
+    @override
+    async def publish_batch(  # type: ignore[override]
         self,
         cmd: "KafkaPublishCommand",
     ) -> None:
@@ -106,9 +107,9 @@ class AsyncConfluentFastProducer(ProducerProto):
         )
 
     @override
-    async def request(
+    async def request(  # type: ignore[override]
         self,
         cmd: "KafkaPublishCommand",
-    ) -> Any:
+    ) -> NoReturn:
         msg = "Kafka doesn't support `request` method without test client."
         raise FeatureNotSupportedException(msg)


### PR DESCRIPTION
# Description

- Non-thread-safe operations have been removed from `AsyncConfluentProducer`
- `AsyncConfluentProducer.publish` method now satisfies the contract
- `AsyncConfluentFastProducer` type hints fixes

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [ ] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
