### PR TITLE
Show a warning only if the message scheme is changed

### DIFF
--- a/faststream/specification/asyncapi/v2_6_0/generate.py
+++ b/faststream/specification/asyncapi/v2_6_0/generate.py
@@ -205,7 +205,7 @@ def _resolve_msg_payloads(
         payloads.update(m.payload.pop(DEF_KEY, {}))
         p_title = m.payload.get("title", f"{channel_name}Payload")
         p_title = clear_key(p_title)
-        if p_title in payloads:
+        if p_title in payloads and payloads[p_title] != m.payload:
             warnings.warn(
                 f"Overwriting the message schema, data types have the same name: `{p_title}`",
                 RuntimeWarning,

--- a/faststream/specification/asyncapi/v3_0_0/generate.py
+++ b/faststream/specification/asyncapi/v3_0_0/generate.py
@@ -231,7 +231,7 @@ def _resolve_msg_payloads(
     payload_name = m.payload.get("title", f"{channel_name}:{message_name}:Payload")
     payload_name = clear_key(payload_name)
 
-    if payload_name in payloads:
+    if payload_name in payloads and payloads[payload_name] != m.payload:
         warnings.warn(
             f"Overwriting the message schema, data types have the same name: `{payload_name}`",
             RuntimeWarning,


### PR DESCRIPTION
# Description

When using the same message schema in multiple handlers, a warning about overwriting the message schema is shown, even though it is the same message. This fix addresses the warning only when using the same name for different message schemas

Fixes #1625

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [x] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
