### PR TITLE
Fix spelling mistake of `/health`

### DIFF
--- a/docs/docs/en/getting-started/asgi.md
+++ b/docs/docs/en/getting-started/asgi.md
@@ -101,7 +101,7 @@ app = AsgiFastStream(
 
 !!! tip
     You do not need to setup all routes using the `asgi_routes=[]` parameter.<br/>
-    You can use the `#!python app.mount("/healh", asgi_endpoint)` method also.
+    You can use the `#!python app.mount("/health", asgi_endpoint)` method also.
 
 ### AsyncAPI Documentation
 


### PR DESCRIPTION
# Description

Fix spelling mistake in ASGI Getting Started docs.

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] My changes do not generate any new warnings
