### PR TITLE
feat: allow broker setting in on_startup hook

### DIFF
--- a/faststream/_internal/application.py
+++ b/faststream/_internal/application.py
@@ -197,6 +197,7 @@ class Application(ABC, AsyncAPIApplication):
     ) -> None:
         self._log(log_level, "FastStream app starting...")
         await self.start(**(run_extra_options or {}))
+        assert self.broker, "You should setup a broker"  # nosec B101
         self._log(
             log_level, "FastStream app started successfully! To exit, press CTRL+C"
         )

--- a/faststream/app.py
+++ b/faststream/app.py
@@ -37,8 +37,6 @@ class FastStream(Application):
         sleep_time: float = 0.1,
     ) -> None:
         """Run FastStream Application."""
-        assert self.broker, "You should setup a broker"  # nosec B101
-
         set_exit(lambda *_: self.exit(), sync=False)
 
         async with catch_startup_validation_error(), self.lifespan_context(

--- a/tests/asgi/testcase.py
+++ b/tests/asgi/testcase.py
@@ -1,4 +1,5 @@
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 from starlette.testclient import TestClient
@@ -14,33 +15,45 @@ class AsgiTestcase:
     def get_test_broker(self, broker) -> Any:
         raise NotImplementedError()
 
-    def test_not_found(self):
-        app = AsgiFastStream()
+    @pytest.mark.asyncio
+    async def test_not_found(self):
+        broker = self.get_broker()
+        app = AsgiFastStream(broker)
 
-        with TestClient(app) as client:
-            response = client.get("/")
-            assert response.status_code == 404
+        async with self.get_test_broker(broker):
+            with TestClient(app) as client:
+                response = client.get("/")
+                assert response.status_code == 404
 
-    def test_ws_not_found(self):
-        app = AsgiFastStream()
+    @pytest.mark.asyncio
+    async def test_ws_not_found(self):
+        broker = self.get_broker()
 
-        with TestClient(app) as client:  # noqa: SIM117
-            with pytest.raises(WebSocketDisconnect):
-                with client.websocket_connect("/ws"):  # raises error
-                    pass
+        app = AsgiFastStream(broker)
 
-    def test_asgi_ping_unhealthy(self):
+        async with self.get_test_broker(broker):
+            with TestClient(app) as client:
+                with pytest.raises(WebSocketDisconnect):
+                    with client.websocket_connect("/ws"):  # raises error
+                        pass
+
+    @pytest.mark.asyncio
+    async def test_asgi_ping_unhealthy(self):
         broker = self.get_broker()
 
         app = AsgiFastStream(
+            broker,
             asgi_routes=[
                 ("/health", make_ping_asgi(broker, timeout=5.0)),
-            ]
+            ],
         )
+        async with self.get_test_broker(broker) as br:
+            br.ping = AsyncMock()
+            br.ping.return_value = False
 
-        with TestClient(app) as client:
-            response = client.get("/health")
-            assert response.status_code == 500
+            with TestClient(app) as client:
+                response = client.get("/health")
+                assert response.status_code == 500
 
     @pytest.mark.asyncio
     async def test_asgi_ping_healthy(self):
@@ -68,14 +81,17 @@ class AsgiTestcase:
                 assert response.status_code == 200
                 assert response.text
 
-    def test_get_decorator(self):
+    @pytest.mark.asyncio
+    async def test_get_decorator(self):
         @get
         async def some_handler(scope):
             return AsgiResponse(body=b"test", status_code=200)
 
-        app = AsgiFastStream(asgi_routes=[("/test", some_handler)])
+        broker = self.get_broker()
+        app = AsgiFastStream(broker, asgi_routes=[("/test", some_handler)])
 
-        with TestClient(app) as client:
-            response = client.get("/test")
-            assert response.status_code == 200
-            assert response.text == "test"
+        async with self.get_test_broker(broker):
+            with TestClient(app) as client:
+                response = client.get("/test")
+                assert response.status_code == 200
+                assert response.text == "test"


### PR DESCRIPTION
# Description

I've managed to achieve the expected behaviour mentioned in the issue #1884.

## Examples

Now it is possible to set broker in on_startup hook

```python
from faststream import FastStream
from faststream.kafka import KafkaBroker


app = FastStream()


@app.on_startup
def bootstrap():
    app.set_broker(KafkaBroker("localhost:9092"))
```

```sh
$ faststream run main:app
2025-02-18 18:26:41,955 INFO     - FastStream app starting...
2025-02-18 18:26:41,968 INFO     - FastStream app started successfully! To exit, press CTRL+C
```

If the broke was not set the exception will be raised

```python
from faststream import FastStream
from faststream.kafka import KafkaBroker


app = FastStream()
```

```sh
$ faststream run main:app
...
AssertionError: You should setup a broker
```

I had to refactor asgi tests a little bit. As this change requires to pass broker to the application, I had to create test brokers to pass all tests.

Fixes #1884

## Type of change

Please delete options that are not relevant.

- [x] New feature (a non-breaking change that adds functionality)

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [x] I have included code examples to illustrate the modifications
