### PR TITLE
docs: Fix distributed spelling error in task scheduling page

### DIFF
--- a/docs/docs/en/scheduling.md
+++ b/docs/docs/en/scheduling.md
@@ -76,7 +76,7 @@ taskiq_broker = AppWrapper(app)
 It allows you to use `taskiq_broker` the same way with the previous example, but saves all original **FastStream** features.
 
 !!! tip
-    Creating a separated *Scheduler* service is a best way to make really distributed and sustainable system. In this case, you can just create an empty **FastStream** broker and use **Taskiq-FastStream** integration to publish your messages (consuming by another services).
+    Creating a separated *Scheduler* service is the best way to make a really distributed and sustainable system. In this case, you can just create an empty **FastStream** broker and use **Taskiq-FastStream** integration to publish your messages (consuming by another services).
 
 ### Generate message payload
 

--- a/docs/docs/en/scheduling.md
+++ b/docs/docs/en/scheduling.md
@@ -10,7 +10,7 @@ search:
 
 # Tasks Scheduling
 
-**FastStream** is a framework for asynchronous service development. It allows you to build disturbed event-based systems in an easy way. Tasks scheduling is a pretty often use case in such systems.
+**FastStream** is a framework for asynchronous service development. It allows you to build distributed event-based systems in an easy way. Tasks scheduling is a pretty often use case in such systems.
 
 Unfortunately, this functional conflicts with the original **FastStream** ideology and can't be implemented as a part of the framework. But, you can integrate scheduling in your **FastStream** application by using some extra dependencies. And we have some receipts on how to make it.
 
@@ -76,7 +76,7 @@ taskiq_broker = AppWrapper(app)
 It allows you to use `taskiq_broker` the same way with the previous example, but saves all original **FastStream** features.
 
 !!! tip
-    Creating a separated *Scheduler* service is a best way to make really disturbed and sustainable system. In this case, you can just create an empty **FastStream** broker and use **Taskiq-FastStream** integration to publish your messages (consuming by another services).
+    Creating a separated *Scheduler* service is a best way to make really distributed and sustainable system. In this case, you can just create an empty **FastStream** broker and use **Taskiq-FastStream** integration to publish your messages (consuming by another services).
 
 ### Generate message payload
 


### PR DESCRIPTION
# Description

Noticed while browsing the documentation.

Although entertaining, I think `distributed` is more appropriate here :grinning: 

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples, or any documentation updates)

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] My changes do not generate any new warnings
