### PR TITLE
Handle non utf-8 bytes in RawMessage

### DIFF
--- a/faststream/redis/parser.py
+++ b/faststream/redis/parser.py
@@ -11,6 +11,8 @@ from typing import (
     Union,
 )
 
+from msgpack import packb, unpackb
+
 from faststream._compat import dump_json, json_loads
 from faststream.broker.message import (
     decode_message,
@@ -98,7 +100,7 @@ class RawMessage:
             correlation_id=correlation_id,
         )
 
-        return dump_json(
+        return packb(  # type: ignore[no-any-return]
             {
                 "data": msg.data,
                 "headers": msg.headers,
@@ -111,8 +113,8 @@ class RawMessage:
 
         try:
             # FastStream message format
-            parsed_data = json_loads(data)
-            data = parsed_data["data"].encode()
+            parsed_data = unpackb(data)
+            data = parsed_data["data"]
             headers = parsed_data["headers"]
 
         except Exception:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,10 @@ confluent = [
 
 nats = ["nats-py>=2.7.0,<=3.0.0"]
 
-redis = ["redis>=5.0.0,<6.0.0"]
+redis = [
+    "redis>=5.0.0,<6.0.0",
+    "msgpack>=1.1.0"
+]
 
 otel = ["opentelemetry-sdk>=1.24.0,<2.0.0"]
 

--- a/tests/brokers/redis/test_parser.py
+++ b/tests/brokers/redis/test_parser.py
@@ -1,9 +1,49 @@
+import json
+
 import pytest
+from msgpack import packb
+from pydantic import BaseModel
 
 from faststream.redis import RedisBroker
+from faststream.redis.parser import RawMessage
 from tests.brokers.base.parser import CustomParserTestcase
+
+
+class M(BaseModel):
+    a: str
 
 
 @pytest.mark.redis
 class TestCustomParser(CustomParserTestcase):
     broker_class = RedisBroker
+
+
+@pytest.mark.parametrize(
+    ("data", "expected_data"),
+    [
+        (
+            {"id": "12345678" * 4, "date": "2021-01-01T00:00:00Z"},
+            json.dumps({"id": "12345678" * 4, "date": "2021-01-01T00:00:00Z"}).encode(),
+        ),
+        (
+            # this is not utf-8 compatible
+            packb({"id": "12345678" * 4, "date": "2021-01-01T00:00:00Z"}),
+            packb({"id": "12345678" * 4, "date": "2021-01-01T00:00:00Z"}),
+        ),
+        (True, b"true"),
+        ([True, False, True], b"[true, false, true]"),
+        (M(a="test"), json.dumps({"a": "test"}).encode()),
+    ],
+)
+@pytest.mark.redis
+def test_raw_message(
+    data,
+    expected_data,
+):
+    msg_bytes = RawMessage.encode(
+        message=data, reply_to=None, headers=None, correlation_id="cor_id"
+    )
+
+    raw_data_result, _ = RawMessage.parse(msg_bytes)
+
+    assert raw_data_result == expected_data

--- a/tests/brokers/redis/test_requests.py
+++ b/tests/brokers/redis/test_requests.py
@@ -1,6 +1,5 @@
-import json
-
 import pytest
+from msgpack import packb, unpackb
 
 from faststream import BaseMiddleware
 from faststream.redis import RedisBroker, RedisRouter, TestRedisBroker
@@ -9,9 +8,9 @@ from tests.brokers.base.requests import RequestsTestcase
 
 class Mid(BaseMiddleware):
     async def on_receive(self) -> None:
-        data = json.loads(self.msg["data"])
+        data = unpackb(self.msg["data"])
         data["data"] *= 2
-        self.msg["data"] = json.dumps(data)
+        self.msg["data"] = packb(data)
 
     async def consume_scope(self, call_next, msg):
         msg._decoded_body = msg._decoded_body * 2


### PR DESCRIPTION
# Description

Use msgpack instead of json to handle non utf-8 bytes in RawMessage. So, redis messages can contain non utf-8 bytes.

Example from issue:

```python
from msgpack import packb

from faststream import FastStream, Logger
from faststream.redis import RedisBroker

broker = RedisBroker()
app = FastStream(broker)


@broker.subscriber("tests")
async def handler(data, logger: Logger):
    logger.info(f"Received data: {data}")


@app.after_startup
async def start():
    await broker.publish(
        packb({"id": "12345678" * 4, "date": "2021-01-01T00:00:00Z"}),
        "tests",
    )
```

This code will result in error:

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x82 in position 0: invalid utf-8
```

With these changes it works just fine:

```
2025-02-27 18:03:57,836 INFO     - FastStream app starting...
2025-02-27 18:03:57,837 INFO     - tests |            - `Handler` waiting for messages
2025-02-27 18:03:57,846 INFO     - FastStream app started successfully! To exit, press CTRL+C
2025-02-27 18:03:57,846 INFO     - tests | 3e4e45c4-8 - Received
2025-02-27 18:03:57,846 INFO     - tests | 3e4e45c4-8 - Received data: b'\x82\xa2id\xd9 12345678123456781234567812345678\xa4date\xb42021-01-01T00:00:00Z'
2025-02-27 18:03:57,846 INFO     - tests | 3e4e45c4-8 - Processed
2025-02-27 18:03:58,442 INFO     - FastStream app shutting down...
2025-02-27 18:03:58,443 INFO     - FastStream app shut down gracefully.
```

Fixes #2061

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [x] I have included code examples to illustrate the modifications
