### PR TITLE
feat: use binary format for redis RawMessage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,8 @@ rabbit = ["aio-pika>=9,<10"]
 kafka = ["aiokafka>=0.9,<0.13"]
 
 confluent = [
-    "confluent-kafka>=2,<3; python_version < '3.13'",
-    "confluent-kafka>=2.6,<3; python_version >= '3.13'",
+    "confluent-kafka>=2,!=2.8.1,<3; python_version < '3.13'",
+    "confluent-kafka>=2.6,!=2.8.1,<3; python_version >= '3.13'",
 ]
 
 nats = ["nats-py>=2.7.0,<=3.0.0"]

--- a/tests/brokers/redis/test_parser.py
+++ b/tests/brokers/redis/test_parser.py
@@ -1,9 +1,42 @@
+import json
+
 import pytest
 
 from faststream.redis import RedisBroker
+from faststream.redis.parser import RawMessage
 from tests.brokers.base.parser import CustomParserTestcase
 
 
 @pytest.mark.redis
 class TestCustomParser(CustomParserTestcase):
     broker_class = RedisBroker
+
+
+@pytest.mark.parametrize(
+    ("data", "expected_data"),
+    [
+        (
+            {"id": "12345678" * 4, "date": "2021-01-01T00:00:00Z"},
+            json.dumps({"id": "12345678" * 4, "date": "2021-01-01T00:00:00Z"}).encode(),
+        ),
+        (
+            # this is not utf-8 compatible
+            b"\x82\xa2",
+            b"\x82\xa2",
+        ),
+        (True, b"true"),
+        ([True, False, True], b"[true, false, true]"),
+    ],
+)
+@pytest.mark.redis
+def test_raw_message(
+    data,
+    expected_data,
+):
+    msg_bytes = RawMessage.encode(
+        message=data, reply_to=None, headers=None, correlation_id="cor_id"
+    )
+
+    raw_data_result, _ = RawMessage.parse(msg_bytes)
+
+    assert raw_data_result == expected_data

--- a/tests/brokers/redis/test_parser.py
+++ b/tests/brokers/redis/test_parser.py
@@ -24,6 +24,9 @@ class TestCustomParser(CustomParserTestcase):
             b"\x82\xa2",
             b"\x82\xa2",
         ),
+        ("]", b"]"),
+        ("]]]]", b"]]]]"),
+        ("check[blabla]123", b"check[blabla]123"),
         (True, b"true"),
         ([True, False, True], b"[true, false, true]"),
     ],
@@ -36,7 +39,6 @@ def test_raw_message(
     msg_bytes = RawMessage.encode(
         message=data, reply_to=None, headers=None, correlation_id="cor_id"
     )
-
     raw_data_result, _ = RawMessage.parse(msg_bytes)
 
     assert raw_data_result == expected_data


### PR DESCRIPTION
# Description

Example:

```python
from msgpack import packb

from faststream import FastStream, Logger
from faststream.redis import RedisBroker

broker = RedisBroker()
app = FastStream(broker)


@broker.subscriber("tests")
async def handler(data, logger: Logger):
    logger.info(f"Received data: {data}")


@app.after_startup
async def start():
    await broker.publish(
        b"\x82\xa2",
        "tests",
    )
```

Currently this code will result in error:

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x82 in position 0: invalid utf-8
```

With these changes it works just fine:

```
2025-02-28 18:36:17,136 INFO     - FastStream app starting...
2025-02-28 18:36:17,136 INFO     - tests |            - `Handler` waiting for messages
2025-02-28 18:36:17,143 INFO     - FastStream app started successfully! To exit, press CTRL+C
2025-02-28 18:36:17,143 INFO     - tests | 256fc941-1 - Received
2025-02-28 18:36:17,143 INFO     - tests | 256fc941-1 - Received data: b'\x82\xa2'
2025-02-28 18:36:17,143 INFO     - tests | 256fc941-1 - Processed
2025-02-28 18:36:18,146 INFO     - FastStream app shutting down...
2025-02-28 18:36:18,147 INFO     - FastStream app shut down gracefully.
```

Fixes #2061

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [x] I have included code examples to illustrate the modifications
