### PR TITLE
Add delay to unassigned consumer warning

### DIFF
--- a/docs/docs/en/kafka/Subscriber/index.md
+++ b/docs/docs/en/kafka/Subscriber/index.md
@@ -77,5 +77,5 @@ async def base_handler(
 ## Concurrent processing
 
 There are two possible modes of concurrent message processing:
-- With `auto_commit=False` and `max_workers` > 1, a handler processes all messages concurrently in a at-most-once semantic.
-- With `auto_commit=True` and `max_workers` > 1, processing is concurrent between topic partitions and sequential within a partition to ensure reliable at-least-once processing. Maximum concurrency is achieved when total number of workers across all application instances running workers in the same consumer group is equal to the number of partitions in the topic. Increasing worker count beyond that will result in idle workers as not more than one consumer from a consumer group can be consuming from the same partition.
+* With `auto_commit=False` and `max_workers` > 1, a handler processes all messages concurrently in a at-most-once semantic.
+* With `auto_commit=True` and `max_workers` > 1, processing is concurrent between topic partitions and sequential within a partition to ensure reliable at-least-once processing. Maximum concurrency is achieved when total number of workers across all application instances running workers in the same consumer group is equal to the number of partitions in the topic. Increasing worker count beyond that will result in idle workers as not more than one consumer from a consumer group can be consuming from the same partition.

--- a/tests/brokers/kafka/test_consume.py
+++ b/tests/brokers/kafka/test_consume.py
@@ -510,7 +510,7 @@ class TestConsume(BrokerRealConsumeTestcase):
                             if x[0][0] == logging.WARNING
                         ]
                     )
-                    == 1
+                    == 2
                 )
             else:
                 assert (

--- a/tests/brokers/kafka/test_consume.py
+++ b/tests/brokers/kafka/test_consume.py
@@ -9,6 +9,7 @@ from aiokafka.admin import AIOKafkaAdminClient, NewTopic
 from faststream.exceptions import AckMessage
 from faststream.kafka import KafkaBroker, TopicPartition
 from faststream.kafka.annotations import KafkaMessage
+from faststream.kafka.listener import LoggingListenerProxy
 from tests.brokers.base.consume import BrokerRealConsumeTestcase
 from tests.tools import spy_decorator
 
@@ -472,7 +473,12 @@ class TestConsume(BrokerRealConsumeTestcase):
         queue: str,
         partitions: int,
         warning: bool,
+        monkeypatch: pytest.MonkeyPatch,
     ):
+        monkeypatch.setattr(
+            LoggingListenerProxy, "_log_unassigned_consumer_delay_seconds", 0
+        )
+
         admin_client = AIOKafkaAdminClient()
         try:
             await admin_client.start()


### PR DESCRIPTION
# Description

I've noticed that a rolling update that temporariry creates an excess of application instances (e.g. if surge > unavailable) will trigger the unassigned consumer warnings unneccessarily.

For example, if normally there are 2 instances with 5 consumers each reading from 10 partitions, an update might create a 3rd instance with an additional 5 consumers before shuttinng down on of the older instances. That would make 5 consumers spread across the 3 instances temporarily unassigned.

I've added a 5 minute delay before a warning. If the consumer becomes assigned during that delay the warning is not triggered. That would allow an update to finish without triggering the warning.

## Type of change

Please delete options that are not relevant.

- [x] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
