### PR TITLE
Fixed nested dataclasses schema generation

### DIFF
--- a/faststream/asyncapi/message.py
+++ b/faststream/asyncapi/message.py
@@ -115,6 +115,9 @@ def get_model_schema(
             # single argument with useless reference
             if param_body.get("$ref"):
                 ref_obj: Dict[str, Any] = next(iter(defs.values()))
+                ref_obj[DEF_KEY] = {
+                    k: v for k, v in defs.items() if k != ref_obj.get("title")
+                }
                 return ref_obj
             else:
                 param_body[DEF_KEY] = defs

--- a/tests/asyncapi/base/arguments.py
+++ b/tests/asyncapi/base/arguments.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Optional, Type, Union
+from typing import List, Optional, Type, Union
 
 import pydantic
 from dirty_equals import IsDict, IsPartialDict, IsStr
@@ -253,7 +253,7 @@ class FastAPICompatible:
         @dataclass
         class Order:
             id: int
-            products: list[Product] = field(default_factory=list)
+            products: List[Product] = field(default_factory=list)
 
         broker = self.broker_class()
 


### PR DESCRIPTION
# Description

- Added DEF_KEY for dataclass-based messages to the schema returned by `faststream/asyncapi/message.py:get_model_schema`
- Extra fix: added __init__.py to /docs module

Fixes #2035 

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [x] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
