### PR TITLE
refactoring ConfluentConfig

### DIFF
--- a/faststream/confluent/config.py
+++ b/faststream/confluent/config.py
@@ -206,7 +206,7 @@ ConfluentConfig = TypedDict(
         "sasl.password": str,
         "sasl.oauthbearer.config": str,
         "enable.sasl.oauthbearer.unsecure.jwt": bool,
-        "oauthbearer_token_refresh_cb": Callable[..., Any],
+        "oauth_cb": Callable[..., Any],
         "sasl.oauthbearer.client.id": str,
         "sasl.oauthbearer.client.secret": str,
         "sasl.oauthbearer.scope": str,
@@ -260,6 +260,7 @@ ConfluentConfig = TypedDict(
         "dr_cb": Callable[..., Any],
         "dr_msg_cb": Callable[..., Any],
         "sticky.partitioning.linger.ms": int,
+        "on_delivery": Callable[..., Any],
     },
     total=False,
 )


### PR DESCRIPTION
# Description

renamed oauthbearer_token_refresh_cb to oauth_cb and introduced on_delivery in ConfluentConfig

Fixes #2089

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [ ] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [ ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
