### PR TITLE
fix: make `CriticalLogMiddleware` respect broker log level (#2130)

### DIFF
--- a/faststream/broker/middlewares/logging.py
+++ b/faststream/broker/middlewares/logging.py
@@ -54,7 +54,7 @@ class CriticalLogMiddleware(BaseMiddleware):
             if exc_type:
                 if issubclass(exc_type, IgnoredException):
                     self.logger.log(
-                        logging.INFO,
+                        self.log_level,
                         exc_val,
                         extra=c,
                     )


### PR DESCRIPTION
# Description

Now method `after_processed` will use broker log level for `IgnoredException`

Fixes #2130

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)


## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
