### PR TITLE
Tweak RabbitMQ queue argument lists

### DIFF
--- a/docs/docs/SUMMARY.md
+++ b/docs/docs/SUMMARY.md
@@ -956,15 +956,15 @@ search:
                         - [BaseRMQInformation](api/faststream/rabbit/schemas/proto/BaseRMQInformation.md)
                     - queue
                         - [ClassicQueueArgs](api/faststream/rabbit/schemas/queue/ClassicQueueArgs.md)
+                        - [ClassicQueueSpecificArgs](api/faststream/rabbit/schemas/queue/ClassicQueueSpecificArgs.md)
                         - [CommonQueueArgs](api/faststream/rabbit/schemas/queue/CommonQueueArgs.md)
-                        - [QueueClassicTypeSpecificArgs](api/faststream/rabbit/schemas/queue/QueueClassicTypeSpecificArgs.md)
-                        - [QueueQuorumTypeSpecificArgs](api/faststream/rabbit/schemas/queue/QueueQuorumTypeSpecificArgs.md)
-                        - [QueueStreamTypeSpecificArgs](api/faststream/rabbit/schemas/queue/QueueStreamTypeSpecificArgs.md)
                         - [QueueType](api/faststream/rabbit/schemas/queue/QueueType.md)
                         - [QuorumQueueArgs](api/faststream/rabbit/schemas/queue/QuorumQueueArgs.md)
+                        - [QuorumQueueSpecificArgs](api/faststream/rabbit/schemas/queue/QuorumQueueSpecificArgs.md)
                         - [RabbitQueue](api/faststream/rabbit/schemas/queue/RabbitQueue.md)
-                        - [SharedQueueClassicAndQuorumArgs](api/faststream/rabbit/schemas/queue/SharedQueueClassicAndQuorumArgs.md)
+                        - [SharedClassicAndQuorumQueueArgs](api/faststream/rabbit/schemas/queue/SharedClassicAndQuorumQueueArgs.md)
                         - [StreamQueueArgs](api/faststream/rabbit/schemas/queue/StreamQueueArgs.md)
+                        - [StreamQueueSpecificArgs](api/faststream/rabbit/schemas/queue/StreamQueueSpecificArgs.md)
                     - reply
                         - [ReplyConfig](api/faststream/rabbit/schemas/reply/ReplyConfig.md)
                 - security

--- a/docs/docs/en/api/faststream/rabbit/schemas/queue/ClassicQueueSpecificArgs.md
+++ b/docs/docs/en/api/faststream/rabbit/schemas/queue/ClassicQueueSpecificArgs.md
@@ -8,4 +8,4 @@ search:
   boost: 0.5
 ---
 
-::: faststream.rabbit.schemas.queue.QueueClassicTypeSpecificArgs
+::: faststream.rabbit.schemas.queue.ClassicQueueSpecificArgs

--- a/docs/docs/en/api/faststream/rabbit/schemas/queue/QuorumQueueSpecificArgs.md
+++ b/docs/docs/en/api/faststream/rabbit/schemas/queue/QuorumQueueSpecificArgs.md
@@ -8,4 +8,4 @@ search:
   boost: 0.5
 ---
 
-::: faststream.rabbit.schemas.queue.QueueStreamTypeSpecificArgs
+::: faststream.rabbit.schemas.queue.QuorumQueueSpecificArgs

--- a/docs/docs/en/api/faststream/rabbit/schemas/queue/SharedClassicAndQuorumQueueArgs.md
+++ b/docs/docs/en/api/faststream/rabbit/schemas/queue/SharedClassicAndQuorumQueueArgs.md
@@ -8,4 +8,4 @@ search:
   boost: 0.5
 ---
 
-::: faststream.rabbit.schemas.queue.QueueQuorumTypeSpecificArgs
+::: faststream.rabbit.schemas.queue.SharedClassicAndQuorumQueueArgs

--- a/docs/docs/en/api/faststream/rabbit/schemas/queue/StreamQueueSpecificArgs.md
+++ b/docs/docs/en/api/faststream/rabbit/schemas/queue/StreamQueueSpecificArgs.md
@@ -8,4 +8,4 @@ search:
   boost: 0.5
 ---
 
-::: faststream.rabbit.schemas.queue.SharedQueueClassicAndQuorumArgs
+::: faststream.rabbit.schemas.queue.StreamQueueSpecificArgs

--- a/faststream/rabbit/schemas/queue.py
+++ b/faststream/rabbit/schemas/queue.py
@@ -191,8 +191,9 @@ CommonQueueArgs = TypedDict(
     total=False,
 )
 
-SharedQueueClassicAndQuorumArgs = TypedDict(
-    "SharedQueueClassicAndQuorumArgs",
+
+SharedClassicAndQuorumQueueArgs = TypedDict(
+    "SharedClassicAndQuorumQueueArgs",
     {
         "x-expires": int,
         "x-message-ttl": int,
@@ -200,33 +201,41 @@ SharedQueueClassicAndQuorumArgs = TypedDict(
         "x-dead-letter-exchange": str,
         "x-dead-letter-routing-key": str,
         "x-max-length": int,
-        "x-max-priority": int,
     },
     total=False,
 )
 
 
-QueueClassicTypeSpecificArgs = TypedDict(
-    "QueueClassicTypeSpecificArgs",
-    {"x-overflow": Literal["drop-head", "reject-publish", "reject-publish-dlx"]},
+ClassicQueueSpecificArgs = TypedDict(
+    "ClassicQueueSpecificArgs",
+    {
+        "x-overflow": Literal["drop-head", "reject-publish", "reject-publish-dlx"],
+        "x-queue-master-locator": Literal["client-local", "balanced"],
+        "x-max-priority": int,
+        "x-queue-mode": Literal["default", "lazy"],
+        "x-queue-version": int,
+    },
     total=False,
 )
 
-QueueQuorumTypeSpecificArgs = TypedDict(
-    "QueueQuorumTypeSpecificArgs",
+
+QuorumQueueSpecificArgs = TypedDict(
+    "QuorumQueueSpecificArgs",
     {
         "x-overflow": Literal["drop-head", "reject-publish"],
         "x-delivery-limit": int,
         "x-quorum-initial-group-size": int,
         "x-quorum-target-group-size": int,
         "x-dead-letter-strategy": Literal["at-most-once", "at-least-once"],
+        "x-max-in-memory-length": int,
+        "x-max-in-memory-bytes": int,
     },
     total=False,
 )
 
 
-QueueStreamTypeSpecificArgs = TypedDict(
-    "QueueStreamTypeSpecificArgs",
+StreamQueueSpecificArgs = TypedDict(
+    "StreamQueueSpecificArgs",
     {
         "x-max-age": str,
         "x-stream-max-segment-size-bytes": int,
@@ -237,17 +246,23 @@ QueueStreamTypeSpecificArgs = TypedDict(
 )
 
 
-class StreamQueueArgs(CommonQueueArgs, QueueStreamTypeSpecificArgs):
-    pass
-
-
 class ClassicQueueArgs(
-    CommonQueueArgs, SharedQueueClassicAndQuorumArgs, QueueClassicTypeSpecificArgs
+    CommonQueueArgs, SharedClassicAndQuorumQueueArgs, ClassicQueueSpecificArgs
 ):
+    """rabbitmq-server/deps/rabbit/src/rabbit_classic_queue.erl."""
+
     pass
 
 
 class QuorumQueueArgs(
-    CommonQueueArgs, SharedQueueClassicAndQuorumArgs, QueueQuorumTypeSpecificArgs
+    CommonQueueArgs, SharedClassicAndQuorumQueueArgs, QuorumQueueSpecificArgs
 ):
+    """rabbitmq-server/deps/rabbit/src/rabbit_quorum_queue.erl."""
+
+    pass
+
+
+class StreamQueueArgs(CommonQueueArgs, StreamQueueSpecificArgs):
+    """rabbitmq-server/deps/rabbit/src/rabbit_stream_queue.erl."""
+
     pass


### PR DESCRIPTION
# Description

RabbitMQ queue declaration argument lists were updated to reflect the RabbitMQ's source code found in:
- [github.com/rabbitmq/rabbitmq-server/blob/main/deps/rabbit/src/rabbit_classic_queue.erl](https://github.com/rabbitmq/rabbitmq-server/blob/main/deps/rabbit/src/rabbit_classic_queue.erl)
- [github.com/rabbitmq/rabbitmq-server/blob/main/deps/rabbit/src/rabbit_quorum_queue.erl](https://github.com/rabbitmq/rabbitmq-server/blob/main/deps/rabbit/src/rabbit_quorum_queue.erl)
- [github.com/rabbitmq/rabbitmq-server/blob/main/deps/rabbit/src/rabbit_stream_queue.erl](https://github.com/rabbitmq/rabbitmq-server/blob/main/deps/rabbit/src/rabbit_stream_queue.erl)

1. `x-max-priority` is not supported by quorum queues, only by classic queues: [rabbitmq.com/docs/priority#overview](https://rabbitmq.com/docs/priority#overview).
2. `x-queue-master-locator` is the legacy naming of `x-queue-leader-locator` that is still supported by classic queues: [rabbitmq.com/docs/clustering#replica-placement](https://rabbitmq.com/docs/clustering#replica-placement)
3. `x-queue-version` and `x-queue-mode` are supported for classic queues by older versions of RabbitMQ: [rabbitmq.com/blog/2023/05/17/rabbitmq-3.12-performance-improvements#classic-queues-changes-to-the-lazy-mode](https://rabbitmq.com/blog/2023/05/17/rabbitmq-3.12-performance-improvements#classic-queues-changes-to-the-lazy-mode)
4. `x-max-in-memory-bytes` and `x-max-in-memory-length` are supported for quorum queues by older versions of RabbitMQ: [rabbitmq.com/blog/2020/04/20/rabbitmq-gets-an-ha-upgrade#quorum-queues-in-the-management-ui](https://rabbitmq.com/blog/2020/04/20/rabbitmq-gets-an-ha-upgrade#quorum-queues-in-the-management-ui)

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [x] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
