### PR TITLE
fix: prevent duplicate logging handler registration when calling broker.start()

### DIFF
--- a/faststream/log/logging.py
+++ b/faststream/log/logging.py
@@ -57,10 +57,21 @@ def get_broker_logger(
     return logger
 
 
+def _handler_exists(logger: logging.Logger) -> bool:
+    # Check if a StreamHandler for sys.stdout already exists in the logger.
+    for handler in logger.handlers:
+        if isinstance(handler, logging.StreamHandler) and handler.stream == sys.stdout:
+            return True
+    return False
+
+
 def set_logger_fmt(
     logger: logging.Logger,
     fmt: str = "%(asctime)s %(levelname)s - %(message)s",
 ) -> None:
+    if _handler_exists(logger):
+        return
+
     handler = logging.StreamHandler(stream=sys.stdout)
 
     formatter = ColourizedFormatter(

--- a/tests/brokers/kafka/test_consume.py
+++ b/tests/brokers/kafka/test_consume.py
@@ -497,7 +497,7 @@ class TestConsume(BrokerRealConsumeTestcase):
         async def handler(msg: str):
             pass
 
-        with patch.object(consume_broker, "logger", Mock()) as mock:
+        with patch.object(consume_broker, "logger", Mock(handlers=[])) as mock:
             async with self.patch_broker(consume_broker) as broker:
                 await broker.start()
                 await broker.close()

--- a/tests/log/test_logging.py
+++ b/tests/log/test_logging.py
@@ -1,0 +1,17 @@
+import logging
+from io import StringIO
+from unittest.mock import patch
+
+from faststream.log.logging import set_logger_fmt
+
+
+def test_duplicates_set_formatter():
+    logger = logging.getLogger(__file__)
+    logger.setLevel(logging.INFO)
+    log_output = StringIO()
+    with patch("sys.stdout", log_output):
+        set_logger_fmt(logger, fmt="%(message)s with format1")
+        set_logger_fmt(logger, fmt="%(message)s with format2")
+
+        logger.info("msg")
+        assert log_output.getvalue().strip() == "msg with format1"


### PR DESCRIPTION
# Description
Fixes #2149

This PR resolves #2149, which describes an issue where StreamHandler(sys.stdout) instances are redundantly added to the logger when the broker.start() function is called multiple times.

This change ensures that a StreamHandler is added only if an identical handler is not already present, preventing duplicate log messages.

The following example demonstrates the issue by running broker.start() in a loop:
```
import asyncio
from faststream import Logger
from faststream.rabbit import RabbitBroker, RabbitExchange, RabbitQueue


def create_new_broker(event: asyncio.Event):
    broker = RabbitBroker(max_consumers=100, reconnect_interval=5)
    exch = RabbitExchange("exchange", auto_delete=True)
    queue_1 = RabbitQueue("test-q-1", auto_delete=True)

    @broker.subscriber(queue_1, exch)
    async def base_handler1(logger: Logger):
        logger.info("base_handler1")
        event.set()

    return broker


async def test_case():
    print("TEST START")
    consumed_event = asyncio.Event()
    broker = create_new_broker(consumed_event)
    await broker.start()
    await broker.publish(queue="test-q-1", exchange="exchange")
    await consumed_event.wait()
    await broker.close()
    print("TEST END")


async def main():
    for i in range(3):
        await test_case()


if __name__ == "__main__":
    asyncio.run(main())
```

There are no documentation changes included in this PR. Please let me know if any updates are needed.

Thank you for your review.




## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-analysis.sh`
- [ ] I have included code examples to illustrate the modifications
