### PR TITLE
docs: better highlight first example

### DIFF
--- a/docs/docs/en/faststream.md
+++ b/docs/docs/en/faststream.md
@@ -162,27 +162,27 @@ JSON-encoded data into Python objects, making it easy to work with structured da
 Here is an example Python app using **FastStream** that consumes data from an incoming data stream and outputs the data to another one:
 
 === "AIOKafka"
-    ```python linenums="1" hl_lines="9"
+    ```python linenums="1" hl_lines="2 4"
     {!> docs_src/index/kafka/basic.py!}
     ```
 
 === "Confluent"
-    ```python linenums="1" hl_lines="9"
+    ```python linenums="1" hl_lines="2 4"
     {!> docs_src/index/confluent/basic.py!}
     ```
 
 === "RabbitMQ"
-    ```python linenums="1" hl_lines="9"
+    ```python linenums="1" hl_lines="2 4"
     {!> docs_src/index/rabbit/basic.py!}
     ```
 
 === "NATS"
-    ```python linenums="1" hl_lines="9"
+    ```python linenums="1" hl_lines="2 4"
     {!> docs_src/index/nats/basic.py!}
     ```
 
 === "Redis"
-    ```python linenums="1" hl_lines="9"
+    ```python linenums="1" hl_lines="2 4"
     {!> docs_src/index/redis/basic.py!}
     ```
 


### PR DESCRIPTION
Before:
<img width="949" alt="Снимок экрана 2025-06-01 в 15 42 07" src="https://github.com/user-attachments/assets/4bb7f749-3140-410e-9259-d0d117fd362b" />

After: we should highlight different parts instead, which are 2nd and 4th lines