### PR TITLE
Markdown Code Blocks Auto Set Language

### DIFF
--- a/.github/workflows/check-md-code-blocks.yaml
+++ b/.github/workflows/check-md-code-blocks.yaml
@@ -22,5 +22,6 @@ jobs:
       - id: fixer
         uses: mahenzon/md-code-block-auto-lang@v1
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           language: python
           silent: 'true'


### PR DESCRIPTION
For the new action to work you'll need to provide access token with rights to update issues and PRs. Here's the [step-by-step guide how to create such token](https://github.com/marketplace/actions/markdown-code-block-auto-lang#configuration).

This code block gets automatically updated to `python` lang if not set:

```
print("Hello World")
```

And this one too:

_Please help_
```
@broker.subscriber("response-subject")
async def consume_responses(msg):
    ...

await broker.publish(
    "Hi!",
    subject="test",
    reply_to="response-subject",
)
```

This one stays untouched:

```go
package main

import "fmt"

func main() {
	fmt.Println("Hello, 世界")
}
```
