### PR TITLE
fix(aiokafka): AttributeError on first _LoggingListener.on_partitions_assigned

### DIFF
--- a/faststream/kafka/helpers/rebalance_listener.py
+++ b/faststream/kafka/helpers/rebalance_listener.py
@@ -38,6 +38,7 @@ def make_logging_listener(
 
 class _LoggingListener(ConsumerRebalanceListener):  # type: ignore[misc]
     _log_unassigned_consumer_delay_seconds = 60 * 2
+    _log_unassigned_consumer_task: asyncio.Task[None] | None
 
     def __init__(
         self,
@@ -49,6 +50,7 @@ class _LoggingListener(ConsumerRebalanceListener):  # type: ignore[misc]
         self.consumer = consumer
         self.logger = logger
         self.log_extra = log_extra
+        self._log_unassigned_consumer_task = None
 
     async def on_partitions_revoked(self, revoked: set["TopicPartition"]) -> None:
         pass


### PR DESCRIPTION
# Description

With AIOKafka when consuming messages we can get this error log :

```python
[django]-[ERROR]-[2025-08-14 12:01:00,855]-[aiokafka.consumer.group_coordinator:517] User provided listener <faststream.kafka.helpers.rebalance_listener._LoggingListener object at 0x77da30e22600> for group test_infra_back failed on partition assignment: {TopicPartition(topic='test_infra_back.ExampleAggregate', partition=0)}
Traceback (most recent call last):
  File "/opt/code/.venv/lib/python3.12/site-packages/aiokafka/consumer/group_coordinator.py", line 515, in _on_join_complete
    await res
  File "/opt/code/.venv/lib/python3.12/site-packages/faststream/kafka/helpers/rebalance_listener.py", line 90, in on_partitions_assigned
    elif self._log_unassigned_consumer_task:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: '_LoggingListener' object has no attribute '_log_unassigned_consumer_task'. Did you mean: 'log_unassigned_consumer'?
```
This PR simply defines `_log_unassigned_consumer_task` to None at class initialization

I did not find tests reaching this part of code

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [x] I have ensured that static analysis tests are passing by running `just static-analysis`
- [ ] I have included code examples to illustrate the modifications
