### PR TITLE
BugFix: add missing serializer in redis test request builder

### DIFF
--- a/faststream/redis/testing.py
+++ b/faststream/redis/testing.py
@@ -133,8 +133,8 @@ class FakeProducer(RedisFastProducer):
             reply_to=cmd.reply_to,
             correlation_id=cmd.correlation_id or gen_cor_id(),
             headers=cmd.headers,
-            serializer=self.broker.config.fd_config._serializer,
             message_format=cmd.message_format,
+            serializer=self.broker.config.fd_config._serializer,
         )
 
         destination = _make_destination_kwargs(cmd)
@@ -190,6 +190,7 @@ class FakeProducer(RedisFastProducer):
                 correlation_id=cmd.correlation_id or gen_cor_id(),
                 headers=cmd.headers,
                 message_format=cmd.message_format,
+                serializer=self.broker.config.fd_config._serializer,
             )
             for m in cmd.batch_bodies
         ]


### PR DESCRIPTION
# Description

adds the missing `serializer` parameter to the redis test `.request` method.

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [ x] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [ ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [ ] I have ensured that static analysis tests are passing by running `just static-analysis`
- [ ] I have included code examples to illustrate the modifications
