### PR TITLE
BUG: ensure that stream read from the subscriber.last_id not the stream_sub

### DIFF
--- a/faststream/redis/subscriber/usecases/stream_subscriber.py
+++ b/faststream/redis/subscriber/usecases/stream_subscriber.py
@@ -133,7 +133,7 @@ class _StreamHandlerMixin(LogicSubscriber):
                 return client.xreadgroup(
                     groupname=stream.group,
                     consumername=stream.consumer,
-                    streams={stream.name: stream.last_id},
+                    streams={stream.name: self.last_id},
                     count=stream.max_records,
                     block=stream.polling_interval,
                     noack=stream.no_ack,


### PR DESCRIPTION
# Description

When reading messages from the redis stream, the consumer always attempts to read from the `last_id` configured on the `stream_sub` instead of the `last_id` being tracked as an instance parameter. By switching over to the `last_id` that is saved on the subscriber, it is now possible to implement custom retry logic in middlewares or as background tasks via `add_task`.

I've labeled this as a bug since it appears to be the _only_ such occurence in this file.

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [x] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [ ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [ ] I have ensured that static analysis tests are passing by running `just static-analysis`
- [ ] I have included code examples to illustrate the modifications
