### PR TITLE
chore(deps): typing extensions to >=4.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ version = "0.6.0"
 
 dependencies = [
     "fast-depends[pydantic]>=3.0.0",
-    "typing-extensions>=4.8.0",
+    "typing-extensions>=4.12.0",
     "anyio>=4.0,<5",
 ]
 


### PR DESCRIPTION
# Description

This PR updates the typing-extensions dependency to version >=4.12.0. This is a maintenance update to ensure compatibility with newer typing features and to align with upstream ecosystem requirements.

Fixes # (issue number)

## Type of change

Please delete options that are not relevant.

- [x] Dependencies

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [ ] I have ensured that static analysis tests are passing by running `just static-analysis`
- [ ] I have included code examples to illustrate the modifications
