### PR TITLE
Reusing router in multiple brokers or routers

### DIFF
--- a/faststream/_internal/configs/broker.py
+++ b/faststream/_internal/configs/broker.py
@@ -74,6 +74,9 @@ class ConfigComposition(Generic[BrokerConfigType]):
     def add_config(self, config: "ConfigType") -> None:
         self.configs = (config, *self.configs)
 
+    def reset(self) -> None:
+        self.configs = (self.configs[-1],)
+
     # broker priority options
     @property
     def producer(self) -> "ProducerProto[Any]":

--- a/faststream/_internal/endpoint/subscriber/call_item.py
+++ b/faststream/_internal/endpoint/subscriber/call_item.py
@@ -81,11 +81,11 @@ class HandlerItem(Generic[MsgType]):
             self.item_parser = parser
             self.item_decoder = decoder
 
-            self.dependant = self.handler.set_wrapped(
-                dependencies=(*broker_dependencies, *self.dependencies),
-                _call_decorators=_call_decorators,
-                config=config,
-            )
+        self.dependant = self.handler.set_wrapped(
+            dependencies=(*broker_dependencies, *self.dependencies),
+            _call_decorators=_call_decorators,
+            config=config,
+        )
 
     @property
     def name(self) -> str:

--- a/tests/brokers/base/include_router.py
+++ b/tests/brokers/base/include_router.py
@@ -145,6 +145,27 @@ class IncludeSubscriberTestcase(IncludeTestcase):
         assert sub2._outer_config.prefix == "1."
         assert sub3._outer_config.prefix == "1.4.5."
 
+    def test_idempotent_include_twice_on_same_broker(self) -> None:
+        router = self.get_router()
+        broker = self.get_broker()
+
+        broker.include_router(router)
+        broker.include_router(router)
+        assert len(router.config.configs) == 2
+        assert router.parent is broker
+
+    def test_reregister_on_include_in_different_brokers(self) -> None:
+        router = self.get_router()
+        broker1 = self.get_broker()
+        broker2 = self.get_broker()
+
+        broker1.include_router(router)
+        broker2.include_router(router)
+
+        assert len(router.config.configs) == 2
+        assert router.parent is broker2
+        assert router not in broker1.routers
+
 
 class IncludePublisherTestcase(IncludeTestcase):
     def get_object(self, router: BrokerRouter[Any] | BrokerUsecase[Any, Any]) -> Any:

--- a/tests/brokers/base/router.py
+++ b/tests/brokers/base/router.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from faststream import Context
 from faststream._internal.broker.router import (
     ArgsContainer,
     BrokerRouter,
@@ -633,3 +634,20 @@ class RouterLocalTestcase(RouterTestcase):
             await br.start()
             await br.publish("hello", queue)
             publisher.mock.assert_called_with("response")
+
+    async def test_func_wrapped_correctly_on_include_in_different_broker(self) -> None:
+        router = self.get_router()
+        broker1 = self.get_broker()
+        broker2 = self.get_broker()
+
+        @router.subscriber("in-queue")
+        async def handle_msg(broker=Context()) -> str:
+            return "test"
+
+        broker1.include_router(router)
+        async with self.patch_broker(broker1) as br:
+            await br.publish({}, "in-queue")
+
+        broker2.include_router(router)
+        async with self.patch_broker(broker2) as br:
+            await br.publish({}, "in-queue")

--- a/tests/brokers/redis/test_router.py
+++ b/tests/brokers/redis/test_router.py
@@ -148,7 +148,6 @@ class TestRouterLocal(RedisMemoryTestcaseConfig, RouterLocalTestcase):
                 ),
                 timeout=3,
             )
-
             assert event.is_set()
 
     async def test_delayed_stream_handlers(


### PR DESCRIPTION
# Description

Fixes #2587

If a router is registered with a new registrar, it will be automatically unregistered from the previous one.

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [x] Bug fix (a non-breaking change that resolves an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [x] I have ensured that static analysis tests are passing by running `just static-analysis`
- [ ] I have included code examples to illustrate the modifications
