### PR TITLE
fix incorrect nats annotations

### DIFF
--- a/faststream/nats/annotations.py
+++ b/faststream/nats/annotations.py
@@ -27,5 +27,5 @@ __all__ = (
 ObjectStorage = Annotated[_ObjectStore, Context(OBJECT_STORAGE_CONTEXT_KEY)]
 NatsMessage = Annotated[_Message, Context("message")]
 NatsBroker = Annotated[_Broker, Context("broker")]
-Client = Annotated[_NatsClient, Context("broker._connection")]
-JsClient = Annotated[_JetStream, Context("broker._stream")]
+Client = Annotated[_NatsClient, Context("broker.config.connection_state.connection")]
+JsClient = Annotated[_JetStream, Context("broker.config.connection_state.stream")]

--- a/faststream/nats/fastapi/__init__.py
+++ b/faststream/nats/fastapi/__init__.py
@@ -11,8 +11,8 @@ from .fastapi import NatsRouter
 
 NatsMessage = Annotated[NM, Context("message")]
 NatsBroker = Annotated[NB, Context("broker")]
-Client = Annotated[NatsClient, Context("broker._connection")]
-JsClient = Annotated[JetStreamContext, Context("broker._stream")]
+Client = Annotated[NatsClient, Context("broker.config.connection_state.connection")]
+JsClient = Annotated[JetStreamContext, Context("broker.config.connection_state.stream")]
 
 __all__ = (
     "Client",


### PR DESCRIPTION
`broker._stream` doesn't exist anymore in annotations

This sent me down a bit of a rabbit hole today! 

I am not sure if there is a reason to be exporting from both `.annotations` and the main module under `nats`.

Fixes # (issue number)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (a non-breaking change that resolves an issue)