### PR TITLE
add nats kv message annotation

### DIFF
--- a/faststream/nats/annotations.py
+++ b/faststream/nats/annotations.py
@@ -7,7 +7,10 @@ from nats.js.object_store import ObjectStore as _ObjectStore
 from faststream._internal.context import Context
 from faststream.annotations import ContextRepo, Logger
 from faststream.nats.broker import NatsBroker as _Broker
-from faststream.nats.message import NatsMessage as _Message
+from faststream.nats.message import (
+    NatsKvMessage as _KVMessage,
+    NatsMessage as _Message,
+)
 from faststream.nats.subscriber.usecases.object_storage_subscriber import (
     OBJECT_STORAGE_CONTEXT_KEY,
 )
@@ -26,6 +29,7 @@ __all__ = (
 
 ObjectStorage = Annotated[_ObjectStore, Context(OBJECT_STORAGE_CONTEXT_KEY)]
 NatsMessage = Annotated[_Message, Context("message")]
+NatsKvMessage = Annotated[_KVMessage, Context("message")]
 NatsBroker = Annotated[_Broker, Context("broker")]
 Client = Annotated[_NatsClient, Context("broker.config.connection_state.connection")]
 JsClient = Annotated[_JetStream, Context("broker.config.connection_state.stream")]


### PR DESCRIPTION
# Description

We want to be able to do something like this:

```python
@broker.subscriber(">", kv_watch=KvWatch(bucket="bucket", declare=False))
async def kv_watch(msg: NatsKvMsg):
    entry = msg.raw_message
    logger.info(
        "KV event key=%s op=%s rev=%s", entry.key, entry.operation, entry.revision
    )
    logger.info(f"Received KV watch event: -> {msg.body.decode()}")
```

But with the normal `NatsMessage` annotation, `msg.raw_message` isn't type-hinted as a kv message, so we get squigglies for `entry.key`, etc.

## Type of change

- [x] New feature (a non-breaking change that adds functionality)