### PR TITLE
fix: Apply log level to custom logger

### DIFF
--- a/docs/docs/en/getting-started/observability/logging.md
+++ b/docs/docs/en/getting-started/observability/logging.md
@@ -34,7 +34,7 @@ This approach offers several advantages:
 
 If you use the **FastStream CLI**, you can change the current logging level of the entire application directly from the command line.
 
-The `--log-level` flag sets the current logging level for both the broker and the `FastStream` app. This allows you to configure the levels of not only the default loggers but also your custom loggers, if you use them inside **FastStream**.
+The `--log-level` flag sets the current logging level for both the broker and the `FastStream` app. This allows you to configure the levels of not only the default loggers but also your custom loggers, if you use them inside **FastStream**. When you supply your own logger instance, FastStream will update its level to the value provided via `log_level` or the CLI `--log-level` flag so that your custom logger respects the chosen verbosity.
 
 ```console
 faststream run serve:app --log-level debug

--- a/faststream/_internal/logger/state.py
+++ b/faststream/_internal/logger/state.py
@@ -71,6 +71,8 @@ class LoggerState:
 
     def _setup(self, context: "ContextRepo", /) -> None:
         if not self.logger:
+            self.params_storage.set_level(self.log_level)
+
             if logger := self.params_storage.get_logger(context=context):
                 self.logger = RealLoggerObject(logger)
             else:


### PR DESCRIPTION
# Description

For manual loggers, ManualLoggerStorage.set_level only applies the configured level when invoked, so if _setup pulls the user-supplied logger without first calling set_level, the logger keeps whatever level it was created with and ignores the log_level/CLI flag. The updated _setup now sets the level before wrapping the manual logger, ensuring the supplied logger honors the configured verbosity.

Note: The fix was found/generated using `open/gpt5.1-codex-max`

Fixes #2677 

## Type of change

- [x] Documentation (typos, code examples, or any documentation updates)
- [x] Bug fix (a non-breaking change that resolves an issue)