### PR TITLE
feat: Implement min_idle_time support for Redis stream subscriber

### DIFF
--- a/faststream/redis/subscriber/usecases/stream_subscriber.py
+++ b/faststream/redis/subscriber/usecases/stream_subscriber.py
@@ -112,31 +112,75 @@ class _StreamHandlerMixin(LogicSubscriber):
                 if "already exists" not in str(e):
                     raise
 
-            def read(
-                _: str,
-            ) -> Awaitable[
-                tuple[
+            if stream.min_idle_time is None:
+
+                def read(
+                    _: str,
+                ) -> Awaitable[
                     tuple[
-                        TopicName,
                         tuple[
+                            TopicName,
                             tuple[
-                                Offset,
-                                dict[bytes, bytes],
+                                tuple[
+                                    Offset,
+                                    dict[bytes, bytes],
+                                ],
+                                ...,
                             ],
-                            ...,
                         ],
+                        ...,
                     ],
-                    ...,
-                ],
-            ]:
-                return client.xreadgroup(
-                    groupname=stream.group,
-                    consumername=stream.consumer,
-                    streams={stream.name: stream.last_id},
-                    count=stream.max_records,
-                    block=stream.polling_interval,
-                    noack=stream.no_ack,
-                )
+                ]:
+                    return client.xreadgroup(
+                        groupname=stream.group,
+                        consumername=stream.consumer,
+                        streams={stream.name: stream.last_id},
+                        count=stream.max_records,
+                        block=stream.polling_interval,
+                        noack=stream.no_ack,
+                    )
+
+            else:
+
+                def read(
+                    _: str,
+                ) -> Coroutine[
+                    Any,
+                    Any,
+                    tuple[
+                        tuple[
+                            TopicName,
+                            tuple[
+                                tuple[
+                                    Offset,
+                                    dict[bytes, bytes],
+                                ],
+                                ...,
+                            ],
+                        ],
+                        ...,
+                    ],
+                ]:
+                    async def xautoclaim() -> tuple[
+                        tuple[TopicName, tuple[tuple[Offset, dict[bytes, bytes]], ...]],
+                        ...,
+                    ]:
+                        stream_message = await client.xautoclaim(
+                            name=self.stream_sub.name,
+                            groupname=self.stream_sub.group,
+                            consumername=self.stream_sub.consumer,
+                            min_idle_time=self.min_idle_time,
+                            start_id=self.autoclaim_start_id,
+                            count=1,
+                        )
+                        stream_name = self.stream_sub.name.encode()
+                        (next_id, messages, _) = stream_message
+                        self.autoclaim_start_id = next_id
+                        if not messages:
+                            return ()
+                        return ((stream_name, messages),)
+
+                    return xautoclaim()
 
         elif self.stream_sub.min_idle_time is None:
 


### PR DESCRIPTION
# Description

Fixed bug where `min_idle_time` parameter was ignored when both `group` and `consumer` were specified in StreamSub, causing FastStream to use `XREADGROUP` instead of `XAUTOCLAIM`.

Fixes #2678

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [x] I have ensured that static analysis tests are passing by running `just static-analysis`
- [ ] I have included code examples to illustrate the modifications
