### PR TITLE
fix(rabbit): handle leading slash in virtualhost correctly

### DIFF
--- a/faststream/rabbit/utils.py
+++ b/faststream/rabbit/utils.py
@@ -18,9 +18,9 @@ def build_virtual_host(
 ) -> str:
     if (not url and not virtualhost) or virtualhost == "/":
         return ""
-    if virtualhost:
+    if virtualhost and virtualhost.startswith("//"):
         return virtualhost.replace("/", "", 1)
-    return path.replace("/", "", 1)
+    return virtualhost or path.replace("/", "", 1)
 
 
 def build_url(

--- a/tests/brokers/rabbit/test_url_builder.py
+++ b/tests/brokers/rabbit/test_url_builder.py
@@ -30,6 +30,26 @@ from faststream.rabbit.utils import build_url
             URL("amqp://guest:guest@localhost:5672//test"),
             id="exotic virtualhost",
         ),
+        pytest.param(
+            {"virtualhost": "/test"},
+            URL("amqp://guest:guest@localhost:5672//test"),
+            id="virtualhost with leading slash",
+        ),
+        pytest.param(
+            {"url": "amqp://guest:guest@localhost:5672", "virtualhost": "/test"},
+            URL("amqp://guest:guest@localhost:5672//test"),
+            id="url combined with slashed virtualhost",
+        ),
+        pytest.param(
+            {"url": "amqp://guest:guest@localhost:5672", "virtualhost": "test"},
+            URL("amqp://guest:guest@localhost:5672/test"),
+            id="url no slash virtualhost without slash",
+        ),
+        pytest.param(
+            {"virtualhost": "test"},
+            URL("amqp://guest:guest@localhost:5672/test"),
+            id="url with slash virtualhost without slash",
+        ),
     ),
 )
 def test_unpack_args(url_kwargs: dict[str, Any], expected_url: URL) -> None:


### PR DESCRIPTION
# Description
Previously, the leading slash was unconditionally stripped from the `virtualhost` argument. This caused a regression where vhosts named `/name` were incorrectly parsed as `name`.

This PR restores backward compatibility with version 0.5.33. Now a leading slash in `virtualhost` (e.g. `/test`) is preserved correctly.
Fixes #2652 

## Type of change
- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist
- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix
- [x] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [x] I have ensured that static analysis tests are passing by running `just static-analysis`
- [ ] I have included code examples to illustrate the modifications
