### PR TITLE
fix(docs): dependencies installation

### DIFF
--- a/justfile
+++ b/justfile
@@ -4,6 +4,8 @@ set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
 # Use sh on Unix-like systems
 set shell := ["sh", "-c"]
 
+export VIRTUAL_ENV := ".venv"  # this requires a pre-commit
+
 
 [doc("All command information")]
 default:
@@ -56,7 +58,7 @@ test-coverage-all +param="tests/":
 
 # Docs
 _docs *params:
-  cd docs && uv run --no-dev --group docs --frozen python docs.py {{params}}
+  cd docs && uv run --frozen python docs.py {{params}}
 
 [doc("Build docs")]
 [group("docs")]


### PR DESCRIPTION
# Description

- Restore dev dependencies for docs build command
- Remove `--no-dev` flag to ensure typer and other dev packages are available
- Export VIRTUAL_ENV for pre-commit compatibility

Previously, `uv run --no-dev` caused ModuleNotFoundError for typer during docs generation.
Now docs can be built with all required dependencies.

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [x] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [x] I have ensured that static analysis tests are passing by running `just static-analysis`
- [ ] I have included code examples to illustrate the modifications
