### PR TITLE
suppress `ServiceUnavailableError` for nats

### DIFF
--- a/faststream/nats/subscriber/usecases/stream_pull_subscriber.py
+++ b/faststream/nats/subscriber/usecases/stream_pull_subscriber.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Optional, cast
 
 import anyio
 from nats.errors import ConnectionClosedError, TimeoutError
+from nats.js.errors import ServiceUnavailableError
 from typing_extensions import override
 
 from faststream._internal.endpoint.subscriber.mixins import ConcurrentMixin, TasksMixin
@@ -76,7 +77,7 @@ class PullStreamSubscriber(
 
         while self.running:  # pragma: no branch
             messages = []
-            with suppress(TimeoutError, ConnectionClosedError):
+            with suppress(TimeoutError, ConnectionClosedError, ServiceUnavailableError):
                 messages = await self.subscription.fetch(
                     batch=self.pull_sub.batch_size,
                     timeout=self.pull_sub.timeout,
@@ -224,7 +225,7 @@ class BatchPullStreamSubscriber(
         assert self.subscription, "You should call `create_subscription` at first."
 
         while self.running:  # pragma: no branch
-            with suppress(TimeoutError, ConnectionClosedError):
+            with suppress(TimeoutError, ConnectionClosedError, ServiceUnavailableError):
                 messages = await self.subscription.fetch(
                     batch=self.pull_sub.batch_size,
                     timeout=self.pull_sub.timeout,


### PR DESCRIPTION
# Description

Suppress another nats error when fetching messages on subscriptions. 

`ServiceUnavailableError` intermittently pops up during jetstream leader elections. My services get stuck in an infinite supervisor loop (see #2632 for more details). 

Since the issue is transient it is a bit difficult to test, but one way I have managed to reproduce is to use a jetstream cluster with 3 replicas, connect with a faststream subscriber, then shut down the cluster, and bring them back up one at a time. 

I think that since this error is transient, it is in line with a TimeoutError, so it should be fine to suppress.

Fixes # (issue number)

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [x] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [ ] I have ensured that static analysis tests are passing by running `just static-analysis`
- [ ] I have included code examples to illustrate the modifications
