### PR TITLE
fix: Bug: AsyncAPI documentation fails when Confluent uses oauth bearer authentication

### DIFF
--- a/faststream/security.py
+++ b/faststream/security.py
@@ -165,7 +165,7 @@ class SASLOAuthBearer(BaseSecurity):
 
     def get_schema(self) -> dict[str, dict[str, str]]:
         """Get the security schema for SASL/OAUTHBEARER authentication."""
-        return {"oauthbearer": {"type": "oauth2", "$ref": ""}}
+        return {"oauthbearer": {"type": "oauth2"}}
 
 
 class SASLGSSAPI(BaseSecurity):

--- a/tests/asyncapi/confluent/v2_6_0/test_security.py
+++ b/tests/asyncapi/confluent/v2_6_0/test_security.py
@@ -113,7 +113,7 @@ class SecurityTestcase(AsyncAPI26Mixin):
                     }),
                     "components": IsPartialDict({
                         "securitySchemes": {
-                            "oauthbearer": {"type": "oauth2", "$ref": ""},
+                            "oauthbearer": {"type": "oauth2"},
                         },
                     }),
                 }),

--- a/tests/asyncapi/confluent/v3_0_0/test_security.py
+++ b/tests/asyncapi/confluent/v3_0_0/test_security.py
@@ -113,7 +113,7 @@ class SecurityTestcase(AsyncAPI30Mixin):
                     }),
                     "components": IsPartialDict({
                         "securitySchemes": {
-                            "oauthbearer": {"type": "oauth2", "$ref": ""},
+                            "oauthbearer": {"type": "oauth2"},
                         },
                     }),
                 }),

--- a/tests/asyncapi/kafka/v2_6_0/test_security.py
+++ b/tests/asyncapi/kafka/v2_6_0/test_security.py
@@ -193,7 +193,7 @@ def test_oauthbearer_security_schema() -> None:
         {"oauthbearer": []},
     ]
     sasl_oauthbearer_security_schema["components"]["securitySchemes"] = {
-        "oauthbearer": {"type": "oauth2", "$ref": ""},
+        "oauthbearer": {"type": "oauth2"},
     }
 
     assert schema == sasl_oauthbearer_security_schema

--- a/tests/asyncapi/kafka/v3_0_0/test_security.py
+++ b/tests/asyncapi/kafka/v3_0_0/test_security.py
@@ -216,7 +216,7 @@ def test_oauthbearer_security_schema() -> None:
         {"$ref": "#/components/securitySchemes/oauthbearer"},
     ]
     sasl_oauthbearer_security_schema["components"]["securitySchemes"] = {
-        "oauthbearer": {"type": "oauth2", "$ref": ""},
+        "oauthbearer": {"type": "oauth2"},
     }
 
     assert schema == sasl_oauthbearer_security_schema


### PR DESCRIPTION
Fixes #2774

# Description

This fixes a FastStream AsyncAPI schema generation bug for SASLOAuthBearer where securitySchemes.oauthbearer was emitted as {"type":"oauth2","$ref":""}.
An empty $ref is invalid and causes AsyncAPI React to attempt file resolution (readFile), leading to a runtime docs error.

Fixes #2774

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [x] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [x] I have ensured that static analysis tests are passing by running `just static-analysis`
- [x] I have included code examples to illustrate the modifications
