### PR TITLE
Preserve exception chains in AsgiFastStream startup

### DIFF
--- a/faststream/asgi/app.py
+++ b/faststream/asgi/app.py
@@ -246,7 +246,7 @@ class AsgiFastStream(Application):
 
             except ExceptionGroup as e:
                 for ex in e.exceptions:
-                    raise ex from None
+                    raise ex from ex.__cause__
 
     async def __start(
         self,

--- a/tests/asgi/test_lifespan.py
+++ b/tests/asgi/test_lifespan.py
@@ -1,0 +1,25 @@
+import pytest
+from starlette.testclient import TestClient
+
+from faststream.asgi import AsgiFastStream
+
+
+@pytest.mark.asyncio()
+async def test_chained_exception_cause_preserved_on_startup_failure() -> None:
+    """AsgiFastStream must not discard __cause__ when re-raising startup exceptions unwrapped from anyio's ExceptionGroup.
+
+    This is a regression test for https://github.com/ag2ai/faststream/issues/2780
+    """
+    app = AsgiFastStream()
+
+    cause = ConnectionError("underlying cause")
+
+    @app.on_startup
+    async def failing_startup() -> None:
+        msg = "application startup failed"
+        raise RuntimeError(msg) from cause
+
+    with pytest.raises(RuntimeError) as exc_info, TestClient(app):
+        pass
+
+    assert exc_info.value.__cause__ is cause


### PR DESCRIPTION
# Description

`raise ex from None` in AsgiFastStream's `start_lifespan_context` was unconditionally clearing `ex.__cause__`, destroying any exception chain deliberately set with `raise B from A` in an `on_startup` hook.

This is now changed to `raise ex from ex.__cause__` so that intentional chains are preserved while the noisy ExceptionGroup wrapper is still suppressed, and a testcase has been added to prevent future regressions.

Fixes #2780

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)


## Checklist

- [ ] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [x] I have ensured that static analysis tests are passing by running `just static-analysis`
- [ ] I have included code examples to illustrate the modifications
