### PR TITLE
fix: use sentinel in StreamMessage.decode() to cache None results

### DIFF
--- a/faststream/message/message.py
+++ b/faststream/message/message.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
 # prevent circular imports
 MsgType = TypeVar("MsgType")
 
+_NOT_CACHED = object()
+
 
 class AckStatus(str, Enum):
     ACKED = "ACKED"
@@ -96,7 +98,9 @@ class StreamMessage(Generic[MsgType]):
         """
         assert self.__decoder, "You should call `set_decoder()` method first."
 
-        if (result := self.__decoded_caches.get(self.__decoder)) is None:
+        if (
+            result := self.__decoded_caches.get(self.__decoder, _NOT_CACHED)
+        ) is _NOT_CACHED:
             result = self.__decoded_caches[self.__decoder] = await self.__decoder(self)
 
         return result

--- a/tests/message/test_message.py
+++ b/tests/message/test_message.py
@@ -1,0 +1,53 @@
+import pytest
+
+from faststream.message import StreamMessage
+
+
+@pytest.mark.asyncio()
+async def test_decode_caches_none_result() -> None:
+    """StreamMessage.decode() must cache a None decoder result.
+
+    Previously, the cache lookup used ``dict.get(key)`` which returns
+    None for missing keys — the same value a decoder may legitimately
+    return.  This caused every subsequent ``decode()`` call to re-invoke
+    the decoder instead of returning the cached None.
+    """
+    call_count = 0
+
+    async def decoder_returning_none(_msg: StreamMessage[bytes]) -> None:
+        nonlocal call_count
+        call_count += 1
+
+    msg: StreamMessage[bytes] = StreamMessage(raw_message=b"", body=b"")
+    msg.set_decoder(decoder_returning_none)
+
+    first = await msg.decode()
+    second = await msg.decode()
+
+    assert first is None
+    assert second is None
+    assert call_count == 1, (
+        f"Decoder was called {call_count} times; expected exactly 1 (cached None)"
+    )
+
+
+@pytest.mark.asyncio()
+async def test_decode_caches_non_none_result() -> None:
+    """Regression guard: non-None results must still be cached."""
+    call_count = 0
+    sentinel = {"key": "value"}
+
+    async def decoder(_msg: StreamMessage[bytes]) -> dict[str, str]:
+        nonlocal call_count
+        call_count += 1
+        return sentinel
+
+    msg: StreamMessage[bytes] = StreamMessage(raw_message=b"", body=b"")
+    msg.set_decoder(decoder)
+
+    first = await msg.decode()
+    second = await msg.decode()
+
+    assert first is sentinel
+    assert second is sentinel
+    assert call_count == 1, f"Decoder was called {call_count} times; expected exactly 1"


### PR DESCRIPTION
# Description

use sentinel in StreamMessage.decode() to cache None results

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [x] I have ensured that static analysis tests are passing by running `just static-analysis`
