### PR TITLE
feat: add on_assign, on_revoke, on_lost callbacks for Confluent subscriber

### DIFF
--- a/faststream/confluent/broker/registrator.py
+++ b/faststream/confluent/broker/registrator.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -78,6 +78,10 @@ class KafkaRegistrator(
             "read_uncommitted",
             "read_committed",
         ] = "read_uncommitted",
+        # rebalance callbacks
+        on_assign: Callable[..., None] | None = None,
+        on_revoke: Callable[..., None] | None = None,
+        on_lost: Callable[..., None] | None = None,
         batch: Literal[False] = False,
         max_records: int | None = None,
         # broker args
@@ -138,6 +142,10 @@ class KafkaRegistrator(
             "read_uncommitted",
             "read_committed",
         ] = "read_uncommitted",
+        # rebalance callbacks
+        on_assign: Callable[..., None] | None = None,
+        on_revoke: Callable[..., None] | None = None,
+        on_lost: Callable[..., None] | None = None,
         batch: Literal[True] = ...,
         max_records: int | None = None,
         # broker args
@@ -198,6 +206,10 @@ class KafkaRegistrator(
             "read_uncommitted",
             "read_committed",
         ] = "read_uncommitted",
+        # rebalance callbacks
+        on_assign: Callable[..., None] | None = None,
+        on_revoke: Callable[..., None] | None = None,
+        on_lost: Callable[..., None] | None = None,
         batch: Literal[False] = False,
         max_records: int | None = None,
         # broker args
@@ -258,6 +270,10 @@ class KafkaRegistrator(
             "read_uncommitted",
             "read_committed",
         ] = "read_uncommitted",
+        # rebalance callbacks
+        on_assign: Callable[..., None] | None = None,
+        on_revoke: Callable[..., None] | None = None,
+        on_lost: Callable[..., None] | None = None,
         batch: bool = False,
         max_records: int | None = None,
         # broker args
@@ -322,6 +338,10 @@ class KafkaRegistrator(
             "read_uncommitted",
             "read_committed",
         ] = "read_uncommitted",
+        # rebalance callbacks
+        on_assign: Callable[..., None] | None = None,
+        on_revoke: Callable[..., None] | None = None,
+        on_lost: Callable[..., None] | None = None,
         batch: bool = False,
         max_records: int | None = None,
         # broker args
@@ -464,6 +484,12 @@ class KafkaRegistrator(
                 return the ALSO. See method docs below.
             batch: Whether to consume messages in batches or not.
             max_records: Number of messages to consume as one batch.
+            on_assign: Callback called when partitions are assigned to the consumer
+                during a rebalance. Receives ``(consumer, partitions)`` arguments.
+            on_revoke: Callback called when partitions are revoked from the consumer
+                during a rebalance. Receives ``(consumer, partitions)`` arguments.
+            on_lost: Callback called when partitions are lost (e.g., due to session
+                timeout). Receives ``(consumer, partitions)`` arguments.
             dependencies: Dependencies list (`[Dependant(),]`) to apply to the subscriber.
             parser: Parser to map original **Message** object to FastStream one.
             decoder: Function to decode FastStream msg bytes body to python objects.
@@ -506,6 +532,9 @@ class KafkaRegistrator(
                 "session_timeout_ms": session_timeout_ms,
                 "heartbeat_interval_ms": heartbeat_interval_ms,
                 "isolation_level": isolation_level,
+                "on_assign": on_assign,
+                "on_revoke": on_revoke,
+                "on_lost": on_lost,
             },
             auto_commit=auto_commit,
             # subscriber args

--- a/faststream/confluent/broker/router.py
+++ b/faststream/confluent/broker/router.py
@@ -135,6 +135,10 @@ class KafkaRoute(SubscriberRoute):
             "read_uncommitted",
             "read_committed",
         ] = "read_uncommitted",
+        # rebalance callbacks
+        on_assign: Callable[..., None] | None = None,
+        on_revoke: Callable[..., None] | None = None,
+        on_lost: Callable[..., None] | None = None,
         batch: bool = False,
         max_records: int | None = None,
         # broker args
@@ -274,6 +278,9 @@ class KafkaRoute(SubscriberRoute):
                 return the ALSO. See method docs below.
             batch: Whether to consume messages in batches or not.
             max_records: Number of messages to consume as one batch.
+            on_assign: Callback called when partitions are assigned to the consumer.
+            on_revoke: Callback called when partitions are revoked from the consumer.
+            on_lost: Callback called when partitions are lost.
             dependencies: Dependencies list (`[Dependant(),]`) to apply to the subscriber.
             parser: Parser to map original **Message** object to FastStream one.
             decoder: Function to decode FastStream msg bytes body to python objects.
@@ -309,6 +316,9 @@ class KafkaRoute(SubscriberRoute):
             session_timeout_ms=session_timeout_ms,
             heartbeat_interval_ms=heartbeat_interval_ms,
             isolation_level=isolation_level,
+            on_assign=on_assign,
+            on_revoke=on_revoke,
+            on_lost=on_lost,
             max_records=max_records,
             batch=batch,
             # basic args

--- a/faststream/confluent/fastapi/fastapi.py
+++ b/faststream/confluent/fastapi/fastapi.py
@@ -430,6 +430,10 @@ class KafkaRouter(StreamRouter[Message | tuple[Message, ...]]):
             "read_uncommitted",
             "read_committed",
         ] = "read_uncommitted",
+        # rebalance callbacks
+        on_assign: Callable[..., None] | None = None,
+        on_revoke: Callable[..., None] | None = None,
+        on_lost: Callable[..., None] | None = None,
         batch: Literal[False] = False,
         max_records: int | None = None,
         # broker args
@@ -497,6 +501,10 @@ class KafkaRouter(StreamRouter[Message | tuple[Message, ...]]):
             "read_uncommitted",
             "read_committed",
         ] = "read_uncommitted",
+        # rebalance callbacks
+        on_assign: Callable[..., None] | None = None,
+        on_revoke: Callable[..., None] | None = None,
+        on_lost: Callable[..., None] | None = None,
         batch: Literal[False] = False,
         max_records: int | None = None,
         # broker args
@@ -564,6 +572,10 @@ class KafkaRouter(StreamRouter[Message | tuple[Message, ...]]):
             "read_uncommitted",
             "read_committed",
         ] = "read_uncommitted",
+        # rebalance callbacks
+        on_assign: Callable[..., None] | None = None,
+        on_revoke: Callable[..., None] | None = None,
+        on_lost: Callable[..., None] | None = None,
         batch: Literal[True] = ...,
         max_records: int | None = None,
         # broker args
@@ -622,6 +634,10 @@ class KafkaRouter(StreamRouter[Message | tuple[Message, ...]]):
             "read_uncommitted",
             "read_committed",
         ] = "read_uncommitted",
+        # rebalance callbacks
+        on_assign: Callable[..., None] | None = None,
+        on_revoke: Callable[..., None] | None = None,
+        on_lost: Callable[..., None] | None = None,
         batch: bool = False,
         max_records: int | None = None,
         # broker args
@@ -693,6 +709,10 @@ class KafkaRouter(StreamRouter[Message | tuple[Message, ...]]):
             "read_uncommitted",
             "read_committed",
         ] = "read_uncommitted",
+        # rebalance callbacks
+        on_assign: Callable[..., None] | None = None,
+        on_revoke: Callable[..., None] | None = None,
+        on_lost: Callable[..., None] | None = None,
         batch: bool = False,
         max_records: int | None = None,
         # broker args
@@ -838,6 +858,12 @@ class KafkaRouter(StreamRouter[Message | tuple[Message, ...]]):
                 return the ALSO. See method docs below.
             batch: Whether to consume messages in batches or not.
             max_records: Number of messages to consume as one batch.
+            on_assign: Callback called when partitions are assigned to the consumer
+                during a rebalance. Receives ``(consumer, partitions)`` arguments.
+            on_revoke: Callback called when partitions are revoked from the consumer
+                during a rebalance. Receives ``(consumer, partitions)`` arguments.
+            on_lost: Callback called when partitions are lost (e.g., due to session
+                timeout). Receives ``(consumer, partitions)`` arguments.
             dependencies: Dependencies list (`[Dependant(),]`) to apply to the subscriber.
             parser: Parser to map original **Message** object to FastStream one.
             decoder: Function to decode FastStream msg bytes body to python objects.
@@ -950,6 +976,9 @@ class KafkaRouter(StreamRouter[Message | tuple[Message, ...]]):
             session_timeout_ms=session_timeout_ms,
             heartbeat_interval_ms=heartbeat_interval_ms,
             isolation_level=isolation_level,
+            on_assign=on_assign,
+            on_revoke=on_revoke,
+            on_lost=on_lost,
             batch=batch,
             max_records=max_records,
             # broker args


### PR DESCRIPTION
# Description

Add rebalance callback parameters (`on_assign`, `on_revoke`, `on_lost`) to the Confluent subscriber, allowing users to monitor partition assignment/revocation events without monkey-patching `AsyncConfluentConsumer`.

These callbacks are passed directly to `confluent_kafka.Consumer.subscribe()`.

**Usage:**
```python
@broker.subscriber(
    "my-topic",
    on_assign=lambda consumer, partitions: print(f"Assigned: {partitions}"),
    on_revoke=lambda consumer, partitions: print(f"Revoked: {partitions}"),
    on_lost=lambda consumer, partitions: print(f"Lost: {partitions}"),
)
async def handler(body: str):
    print(body)
```

Fixes #1676

## Type of change

- [x] New feature (a non-breaking change that adds functionality)

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [ ] I have ensured that static analysis tests are passing by running `just static-analysis`
- [x] I have included code examples to illustrate the modifications