### PR TITLE
fix: corrected security parsing for mqtt broker

### DIFF
--- a/faststream/mqtt/security.py
+++ b/faststream/mqtt/security.py
@@ -15,12 +15,14 @@ def parse_security(security: BaseSecurity | None) -> dict[str, Any]:
 
 
 def _parse_base_security(security: BaseSecurity) -> dict[str, Any]:
-    return {"tls": security.ssl_context}
+    if security.use_ssl:
+        return {"tls": security.ssl_context or True}
+    return {"tls": False}
 
 
 def _parse_sasl_plaintext(security: SASLPlaintext) -> dict[str, Any]:
     return {
-        "tls": security.ssl_context,
+        **_parse_base_security(security),
         "username": security.username,
         "password": security.password,
     }

--- a/tests/brokers/mqtt/test_security.py
+++ b/tests/brokers/mqtt/test_security.py
@@ -20,6 +20,7 @@ SSL_CONTEXT = create_default_context()
         (SSL_CONTEXT, True, {"tls": SSL_CONTEXT}),
     ),
 )
+@pytest.mark.mqtt()
 def test_parse_base_security(
     ssl_context: SSLContext, use_ssl: bool | None, expected_parse_result: dict[str, Any]
 ) -> None:

--- a/tests/brokers/mqtt/test_security.py
+++ b/tests/brokers/mqtt/test_security.py
@@ -1,0 +1,30 @@
+from ssl import SSLContext, create_default_context
+from typing import Any
+
+import pytest
+
+from faststream.mqtt.security import _parse_base_security
+from faststream.security import BaseSecurity
+
+SSL_CONTEXT = create_default_context()
+
+
+@pytest.mark.parametrize(
+    ("ssl_context", "use_ssl", "expected_parse_result"),
+    (
+        (None, None, {"tls": False}),
+        (None, False, {"tls": False}),
+        (None, True, {"tls": True}),
+        (SSL_CONTEXT, None, {"tls": SSL_CONTEXT}),
+        (SSL_CONTEXT, False, {"tls": SSL_CONTEXT}),
+        (SSL_CONTEXT, True, {"tls": SSL_CONTEXT}),
+    ),
+)
+def test_parse_base_security(
+    ssl_context: SSLContext, use_ssl: bool | None, expected_parse_result: dict[str, Any]
+) -> None:
+    security = BaseSecurity(ssl_context=ssl_context, use_ssl=use_ssl)
+
+    parsed = _parse_base_security(security=security)
+
+    assert expected_parse_result == parsed


### PR DESCRIPTION
# Description

Fixed security argument parsing in broker to correctly pass it to MQTTClient.

Fixes #2831

## Type of change

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`just lint` shows no errors)
- [x] I have conducted a self-review of my own code
- [x] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [x] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `just test-coverage`
- [x] I have ensured that static analysis tests are passing by running `just static-analysis`
- [x] I have included code examples to illustrate the modifications
